### PR TITLE
Implement new sbreload command for a faster respring

### DIFF
--- a/Zebra/Console/ZBConsoleViewController.m
+++ b/Zebra/Console/ZBConsoleViewController.m
@@ -281,8 +281,7 @@
     //Bye!
     NSTask *task = [[NSTask alloc] init];
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    
-    if([fileManager fileExistsAtPath:@"/usr/bin/sbreload"]){
+    if([fileManager fileExistsAtPath:@"/chimera"]){
         [task setLaunchPath:@"/usr/bin/sbreload"];
     } else {
         [task setLaunchPath:@"/usr/bin/killall"];

--- a/Zebra/Console/ZBConsoleViewController.m
+++ b/Zebra/Console/ZBConsoleViewController.m
@@ -280,8 +280,14 @@
 - (void)restartSpringBoard {
     //Bye!
     NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath:@"/usr/bin/killall"];
-    [task setArguments:@[@"-9", @"backboardd"]];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    if([fileManager fileExistsAtPath:@"/usr/bin/sbreload"]){
+        [task setLaunchPath:@"/usr/bin/sbreload"];
+    } else {
+        [task setLaunchPath:@"/usr/bin/killall"];
+        [task setArguments:@[@"-9", @"backboardd"]];
+    }
     
     [task launch];
 }


### PR DESCRIPTION
The Chimera jailbreak brought a new way to respring called sbreload.  I took advantage of that and Implemented it into Zebra. Don't worry, I also made it compatible with the old respring if the sbreload binary isn't found on the device.