### PR TITLE
SwipeForMore-like feature for Zebra.

### DIFF
--- a/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -191,7 +191,7 @@
             UIBarButtonItem *removeButton = [[UIBarButtonItem alloc] initWithTitle:@"Remove" style:UIBarButtonItemStylePlain target:self action:@selector(removePackage)];
             self.navigationItem.rightBarButtonItem = removeButton;
         }
-        hasUpdate = possibleActions & (1 << ZBQueueTypeUpgrade);
+        hasUpdate = possibleActions & ZBQueueTypeUpgrade;
     }
     else {
         UIBarButtonItem *installButton = [[UIBarButtonItem alloc] initWithTitle:@"Install" style:UIBarButtonItemStylePlain target:self action:@selector(installPackage)];
@@ -211,7 +211,7 @@
     
     NSUInteger possibleActions = [package possibleActions];
     
-    if (possibleActions & (1 << ZBQueueTypeRemove)) {
+    if (possibleActions & ZBQueueTypeRemove) {
         UIAlertAction *remove = [UIAlertAction actionWithTitle:@"Remove" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             ZBQueue *queue = [ZBQueue sharedInstance];
             [queue addPackage:self->package toQueue:ZBQueueTypeRemove];
@@ -223,7 +223,7 @@
         [alert addAction:remove];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeReinstall)) {
+    if (possibleActions & ZBQueueTypeReinstall) {
         UIAlertAction *reinstall = [UIAlertAction actionWithTitle:@"Reinstall" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             ZBQueue *queue = [ZBQueue sharedInstance];
             [queue addPackage:self->package toQueue:ZBQueueTypeReinstall];
@@ -235,7 +235,7 @@
         [alert addAction:reinstall];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeDowngrade)) {
+    if (possibleActions & ZBQueueTypeDowngrade) {
         UIAlertAction *downgrade = [UIAlertAction actionWithTitle:@"Downgrade" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [alert dismissViewControllerAnimated:true completion:nil];
             [self downgradePackage];
@@ -322,7 +322,7 @@
     NSUInteger possibleActions = [package possibleActions];
     NSMutableArray *actions = [NSMutableArray array];
     
-    if (possibleActions & (1 << ZBQueueTypeRemove)) {
+    if (possibleActions & ZBQueueTypeRemove) {
         UIPreviewAction *remove = [UIPreviewAction actionWithTitle:@"Remove" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self removePackage];
         }];
@@ -330,7 +330,7 @@
         [actions addObject:remove];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeReinstall)) {
+    if (possibleActions & ZBQueueTypeReinstall) {
         UIPreviewAction *reinstall = [UIPreviewAction actionWithTitle:@"Reinstall" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             ZBQueue *queue = [ZBQueue sharedInstance];
             [queue addPackage:self->package toQueue:ZBQueueTypeReinstall];
@@ -341,7 +341,7 @@
         [actions addObject:reinstall];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeDowngrade)) {
+    if (possibleActions & ZBQueueTypeDowngrade) {
         UIPreviewAction *downgrade = [UIPreviewAction actionWithTitle:@"Downgrade" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self downgradePackage];
         }];

--- a/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -180,20 +180,18 @@
 }
 
 - (void)configureNavButton {
-    ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
-    if ([[package repo] repoID] == 0 || [databaseManager packageIsInstalled:package versionStrict:false]) {
-        hasUpdate = [databaseManager packageHasUpdate:package];
-        otherVersions = [databaseManager otherVersionsForPackage:package];
-        if ([otherVersions count] > 1) { //Modify, reinstall, remove, downgrade (maybe)
+    NSUInteger possibleActions = [package possibleActions];
+    otherVersions = [package otherVersions];
+    if ([package isInstalled]) {
+        if (possibleActions & (1 << ZBQueueTypeDowngrade)) { //Modify, reinstall, remove, downgrade (maybe)
             UIBarButtonItem *modifyButton = [[UIBarButtonItem alloc] initWithTitle:@"Modify" style:UIBarButtonItemStylePlain target:self action:@selector(modifyPackage)];
             self.navigationItem.rightBarButtonItem = modifyButton;
-        }
-        else { //Show remove, its just a local package
+        } else { //Show remove, its just a local package
             UIBarButtonItem *removeButton = [[UIBarButtonItem alloc] initWithTitle:@"Remove" style:UIBarButtonItemStylePlain target:self action:@selector(removePackage)];
             self.navigationItem.rightBarButtonItem = removeButton;
         }
-    }
-    else {
+        hasUpdate = possibleActions & (1 << ZBQueueTypeUpgrade);
+    } else {
         UIBarButtonItem *installButton = [[UIBarButtonItem alloc] initWithTitle:@"Install" style:UIBarButtonItemStylePlain target:self action:@selector(installPackage)];
         self.navigationItem.rightBarButtonItem = installButton;
     }
@@ -207,29 +205,34 @@
 }
 
 - (void)modifyPackage {
+    NSUInteger possibleActions = [package possibleActions];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[package name] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
-    UIAlertAction *remove = [UIAlertAction actionWithTitle:@"Remove" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        ZBQueue *queue = [ZBQueue sharedInstance];
-        [queue addPackage:self->package toQueue:ZBQueueTypeRemove];
+    if (possibleActions & (1 << ZBQueueTypeRemove)) {
+        UIAlertAction *remove = [UIAlertAction actionWithTitle:@"Remove" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            ZBQueue *queue = [ZBQueue sharedInstance];
+            [queue addPackage:self->package toQueue:ZBQueueTypeRemove];
+            
+            [alert dismissViewControllerAnimated:true completion:nil];
+            [self presentQueue];
+        }];
+    
+        [alert addAction:remove];
+    }
+    
+    if (possibleActions & (1 << ZBQueueTypeReinstall)) {
+        UIAlertAction *reinstall = [UIAlertAction actionWithTitle:@"Reinstall" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            ZBQueue *queue = [ZBQueue sharedInstance];
+            [queue addPackage:self->package toQueue:ZBQueueTypeReinstall];
+            
+            [alert dismissViewControllerAnimated:true completion:nil];
+            [self presentQueue];
+        }];
         
-        [alert dismissViewControllerAnimated:true completion:nil];
-        [self presentQueue];
-    }];
+        [alert addAction:reinstall];
+    }
     
-    [alert addAction:remove];
-    
-    UIAlertAction *reinstall = [UIAlertAction actionWithTitle:@"Reinstall" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        ZBQueue *queue = [ZBQueue sharedInstance];
-        [queue addPackage:self->package toQueue:ZBQueueTypeReinstall];
-        
-        [alert dismissViewControllerAnimated:true completion:nil];
-        [self presentQueue];
-    }];
-    
-    [alert addAction:reinstall];
-    
-    if ([otherVersions count] > 2) {
+    if (possibleActions & (1 << ZBQueueTypeDowngrade)) {
         UIAlertAction *downgrade = [UIAlertAction actionWithTitle:@"Downgrade" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [alert dismissViewControllerAnimated:true completion:nil];
             [self downgradePackage];
@@ -265,9 +268,6 @@
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"Downgrade %@", [package name]] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
     for (ZBPackage *downPackage in otherVersions) {
-        if ([[downPackage repo] repoID] == 0 || [[downPackage version] isEqualToString:[package version]]) {
-            continue;
-        }
         
         UIAlertAction *action = [UIAlertAction actionWithTitle:[downPackage version] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             ZBQueue *queue = [ZBQueue sharedInstance];

--- a/Zebra/Packages/Controllers/ZBPackageListTableViewController.m
+++ b/Zebra/Packages/Controllers/ZBPackageListTableViewController.m
@@ -323,7 +323,7 @@
     }];
     [actions addObject:deleteAction];
     
-    if (possibleActions & (1 << ZBQueueTypeInstall)) {
+    if (possibleActions & ZBQueueTypeInstall) {
         UITableViewRowAction *installAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Install" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
             [queue addPackage:package toQueue:ZBQueueTypeInstall];
         }];
@@ -331,7 +331,7 @@
         [actions addObject:installAction];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeReinstall)) {
+    if (possibleActions & ZBQueueTypeReinstall) {
         UITableViewRowAction *reinstallAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Reinstall" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
             [queue addPackage:package toQueue:ZBQueueTypeReinstall];
         }];
@@ -339,7 +339,7 @@
         [actions addObject:reinstallAction];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeDowngrade)) {
+    if (possibleActions & ZBQueueTypeDowngrade) {
         UITableViewRowAction *downgradeAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Downgrade" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
             [self downgradePackage:package tableView:tableView indexPath:indexPath versions:[package otherVersions]];
         }];
@@ -347,7 +347,7 @@
         [actions addObject:downgradeAction];
     }
     
-    if (possibleActions & (1 << ZBQueueTypeUpgrade)) {
+    if (possibleActions & ZBQueueTypeUpgrade) {
         UITableViewRowAction *upgradeAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Upgrade" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
             [queue addPackage:package toQueue:ZBQueueTypeUpgrade];
         }];

--- a/Zebra/Packages/Controllers/ZBPackageListTableViewController.m
+++ b/Zebra/Packages/Controllers/ZBPackageListTableViewController.m
@@ -177,6 +177,46 @@
     [self presentQueue];
 }
 
+- (ZBPackage *)packageAtIndexPath:(NSIndexPath *)indexPath {
+    if (needsUpdatesSection &&  indexPath.section == 0) {
+        return (ZBPackage *)[updates objectAtIndex:indexPath.row];
+    }
+    else {
+        return (ZBPackage *)[packages objectAtIndex:indexPath.row];
+    }
+}
+
+- (void)downgradePackage:(ZBPackage *)package tableView:(UITableView *)tableView indexPath:(NSIndexPath *)indexPath versions:(NSArray *)otherVersions {
+    // TODO: I don't exactly like this because it also exists on ZBPackageDepictionViewController, should we somehow combine them - PoomSmart
+    
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"Downgrade %@", [package name]] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    
+    for (ZBPackage *downPackage in otherVersions) {
+        
+        UIAlertAction *action = [UIAlertAction actionWithTitle:[downPackage version] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            ZBQueue *queue = [ZBQueue sharedInstance];
+            [queue addPackage:downPackage toQueue:ZBQueueTypeInstall];
+            
+            [alert dismissViewControllerAnimated:true completion:nil];
+            [self presentQueue];
+        }];
+        
+        [alert addAction:action];
+    }
+    
+    UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [alert dismissViewControllerAnimated:true completion:nil];
+    }];
+    
+    [alert addAction:cancel];
+    
+    ZBPackageTableViewCell *cell = (ZBPackageTableViewCell *)[self tableView:tableView cellForRowAtIndexPath:indexPath];
+    alert.popoverPresentationController.sourceView = cell;
+    alert.popoverPresentationController.sourceRect = cell.bounds;
+    
+    [self presentViewController:alert animated:true completion:nil];
+}
+
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -201,16 +241,9 @@
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(ZBPackageTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (needsUpdatesSection &&  indexPath.section == 0) {
-        ZBPackage *package = (ZBPackage *)[updates objectAtIndex:indexPath.row];
-        
-        [cell updateData:package];
-    }
-    else {
-        ZBPackage *package = (ZBPackage *)[packages objectAtIndex:indexPath.row];
-        
-        [cell updateData:package];
-        
+    ZBPackage *package = [self packageAtIndexPath:indexPath];
+    [cell updateData:package];
+    if (!needsUpdatesSection || indexPath.section != 0) {
         if ((indexPath.row >= [packages count] - ([packages count] / 10)) && ([repo repoID] != 0)) {
             [self loadNextPackages];
         }
@@ -273,6 +306,60 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
     return 5;
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return YES;
+}
+
+- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath {
+    ZBPackage *package = [self packageAtIndexPath:indexPath];
+    NSMutableArray *actions = [NSMutableArray array];
+    NSUInteger possibleActions = [package possibleActions];
+    ZBQueue *queue = [ZBQueue sharedInstance];
+    
+    UITableViewRowAction *deleteAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive title:@"Remove" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+        [queue addPackage:package toQueue:ZBQueueTypeRemove];
+    }];
+    [actions addObject:deleteAction];
+    
+    if (possibleActions & (1 << ZBQueueTypeInstall)) {
+        UITableViewRowAction *installAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Install" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            [queue addPackage:package toQueue:ZBQueueTypeInstall];
+        }];
+        installAction.backgroundColor = [UIColor systemBlueColor];
+        [actions addObject:installAction];
+    }
+    
+    if (possibleActions & (1 << ZBQueueTypeReinstall)) {
+        UITableViewRowAction *reinstallAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Reinstall" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            [queue addPackage:package toQueue:ZBQueueTypeReinstall];
+        }];
+        reinstallAction.backgroundColor = [UIColor orangeColor];
+        [actions addObject:reinstallAction];
+    }
+    
+    if (possibleActions & (1 << ZBQueueTypeDowngrade)) {
+        UITableViewRowAction *downgradeAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Downgrade" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            [self downgradePackage:package tableView:tableView indexPath:indexPath versions:[package otherVersions]];
+        }];
+        downgradeAction.backgroundColor = [UIColor purpleColor];
+        [actions addObject:downgradeAction];
+    }
+    
+    if (possibleActions & (1 << ZBQueueTypeUpgrade)) {
+        UITableViewRowAction *upgradeAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:@"Upgrade" handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            [queue addPackage:package toQueue:ZBQueueTypeUpgrade];
+        }];
+        upgradeAction.backgroundColor = [UIColor systemBlueColor];
+        [actions addObject:upgradeAction];
+    }
+    
+    return actions;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView setEditing:NO animated:YES];
 }
 
 #pragma mark - Navigation

--- a/Zebra/Packages/Helpers/ZBPackage.h
+++ b/Zebra/Packages/Helpers/ZBPackage.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getField:(NSString *)field;
 - (BOOL)isStrictlyInstalled;
 - (BOOL)isInstalled;
+- (NSMutableArray *)otherVersions;
+- (NSUInteger)possibleActions;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Zebra/Packages/Helpers/ZBPackage.h
+++ b/Zebra/Packages/Helpers/ZBPackage.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getField:(NSString *)field;
 - (BOOL)isStrictlyInstalled;
 - (BOOL)isInstalled;
+- (BOOL)isInstalledRepoZero;
 - (NSMutableArray *)otherVersions;
 - (NSUInteger)possibleActions;
 @end

--- a/Zebra/Packages/Helpers/ZBPackage.m
+++ b/Zebra/Packages/Helpers/ZBPackage.m
@@ -377,18 +377,18 @@
     // Bits order: Downgrade - Upgrade - Reinstall - Remove - Install
     ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
     if ([self isInstalledRepoZero]) {
-        actions |= 1 << ZBQueueTypeReinstall;
+        actions |= ZBQueueTypeReinstall;
         if ([databaseManager packageHasUpdate:self]) {
-            actions |= 1 << ZBQueueTypeUpgrade;
+            actions |= ZBQueueTypeUpgrade;
         }
     }
     else {
-        actions |= 1 << ZBQueueTypeInstall; // Install
+        actions |= ZBQueueTypeInstall; // Install
     }
-    actions |= 1 << ZBQueueTypeRemove; // Remove
+    actions |= ZBQueueTypeRemove; // Remove
     NSArray *otherVersions = [self otherVersions];
     if (otherVersions.count > 1) {
-        actions |= 1 << ZBQueueTypeDowngrade; // Downgrade
+        actions |= ZBQueueTypeDowngrade; // Downgrade
     }
     return actions;
 }

--- a/Zebra/Packages/Helpers/ZBPackage.m
+++ b/Zebra/Packages/Helpers/ZBPackage.m
@@ -348,9 +348,13 @@
     return [databaseManager packageIsInstalled:self versionStrict:true];
 }
 
-- (BOOL)isInstalled {
+- (BOOL)isInstalledRepoZero {
     ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
-    return [repo repoID] == 0 || [repo repoID] == -1 || [databaseManager packageIsInstalled:self versionStrict:false];
+    return [repo repoID] == 0 || [databaseManager packageIsInstalled:self versionStrict:false];
+}
+
+- (BOOL)isInstalled {
+    return [repo repoID] == -1 || [self isInstalledRepoZero];
 }
 
 - (NSMutableArray *)otherVersions {
@@ -372,7 +376,7 @@
     NSUInteger actions = 0;
     // Bits order: Downgrade - Upgrade - Reinstall - Remove - Install
     ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
-    if ([self isInstalled]) {
+    if ([self isInstalledRepoZero]) {
         actions |= 1 << ZBQueueTypeReinstall;
         if ([databaseManager packageHasUpdate:self]) {
             actions |= 1 << ZBQueueTypeUpgrade;

--- a/Zebra/Queue/ZBQueue.m
+++ b/Zebra/Queue/ZBQueue.m
@@ -87,6 +87,8 @@
             }
             break;
         }
+        default:
+            break;
     }
 }
 
@@ -95,7 +97,7 @@
         [self addPackage:package toQueue:queue ignoreDependencies:true];
     }
     
-    NSString *q;
+    NSString *q = nil;
     switch (queue) {
         case ZBQueueTypeInstall: {
             q = @"Install";
@@ -109,11 +111,15 @@
         case ZBQueueTypeUpgrade: {
             q = @"Upgrade";
         }
+        default:
+            break;
     }
     
-    for (ZBPackage *package in _managedQueue[q]) {
-        [self enqueueDependenciesForPackage:package];
-        [self checkForConflictionsWithPackage:package state:queue == ZBQueueTypeRemove ? 1 : 0];
+    if (q) {
+        for (ZBPackage *package in _managedQueue[q]) {
+            [self enqueueDependenciesForPackage:package];
+            [self checkForConflictionsWithPackage:package state:queue == ZBQueueTypeRemove ? 1 : 0];
+        }
     }
 }
 
@@ -153,6 +159,8 @@
             [_managedQueue setObject:upgradeArray forKey:@"Upgrade"];
             break;
         }
+        default:
+            break;
     }
 }
 
@@ -268,6 +276,8 @@
         case ZBQueueTypeUpgrade: {
             return [_managedQueue[@"Upgrade"] objectAtIndex:index];
         }
+        default:
+            return nil;
     }
 }
 

--- a/Zebra/Queue/ZBQueueType.h
+++ b/Zebra/Queue/ZBQueueType.h
@@ -13,7 +13,8 @@ typedef enum {
     ZBQueueTypeInstall,
     ZBQueueTypeRemove,
     ZBQueueTypeReinstall,
-    ZBQueueTypeUpgrade
+    ZBQueueTypeUpgrade,
+    ZBQueueTypeDowngrade // Note: Not really used directly, this is to make code less complicated - PoomSmart
 } ZBQueueType;
 
 #endif /* ZBQueueType_h */

--- a/Zebra/Queue/ZBQueueType.h
+++ b/Zebra/Queue/ZBQueueType.h
@@ -10,11 +10,11 @@
 #define ZBQueueType_h
 
 typedef enum {
-    ZBQueueTypeInstall,
-    ZBQueueTypeRemove,
-    ZBQueueTypeReinstall,
-    ZBQueueTypeUpgrade,
-    ZBQueueTypeDowngrade // Note: Not really used directly, this is to make code less complicated - PoomSmart
+    ZBQueueTypeInstall      = 1 << 0,
+    ZBQueueTypeRemove       = 1 << 1,
+    ZBQueueTypeReinstall    = 1 << 2,
+    ZBQueueTypeUpgrade      = 1 << 3,
+    ZBQueueTypeDowngrade    = 1 << 4 // Note: Not really used directly, this is to make code less complicated - PoomSmart
 } ZBQueueType;
 
 #endif /* ZBQueueType_h */

--- a/Zebra/UIColor+GlobalColors.h
+++ b/Zebra/UIColor+GlobalColors.h
@@ -18,3 +18,7 @@
 +(UIColor*)cellPrimaryTextColor;
 +(UIColor*)cellSecondaryTextColor;
 @end
+
+@interface UIColor (Private)
++(UIColor*)systemBlueColor;
+@end


### PR DESCRIPTION
In this pull request, users will be able to swipe right-to-left on a package cell to perform certain actions directly without having to go through its depiction page. Design is not yet finalized, users will see actions as text blocks.

One slight issue is user feedback, once they perform, let's say, install action, they won't know if the package has already been queued up until they go to Packages tab and tap on Queue button at top-left. There is no indicator in a package cell Like SwipeForMore, the core design is to not show the queue page, allowing users to go through packages quicker.

Also, this pull request attempts to fix logic in "Modify" button in the package depiction page. Some packages can only be removed, when in fact, they have an appropriate repo and clearly not local packages.

Below is a screenshot to show what the feature look like.
![Image from iOS](https://user-images.githubusercontent.com/3608783/57577448-3472b480-74a1-11e9-8282-18eb15cb6384.jpg)