### PR TITLE
[Queue] No, we just remove all the entries of the dictionary's keys

### DIFF
--- a/Zebra/Queue/ZBQueue.m
+++ b/Zebra/Queue/ZBQueue.m
@@ -283,7 +283,6 @@
 }
 
 - (void)clearQueue {
-    _managedQueue = [NSMutableDictionary new];
     [_managedQueue[@"Install"] removeAllObjects];
     [_managedQueue[@"Remove"] removeAllObjects];
     [_managedQueue[@"Reinstall"] removeAllObjects];


### PR DESCRIPTION
This fixes a bug when sometimes packages won't show in the queue.