### PR TITLE
[Parsel] Correctly parse the package's long description.

### DIFF
--- a/Zebra/Parsel/dict.c
+++ b/Zebra/Parsel/dict.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 
 dict* dict_new() {
-    dict *dictionary = (dict *)malloc(sizeof(dict));
+    dict *dictionary = malloc(sizeof(dict));
     assert(dictionary != NULL);
     dictionary->head = NULL;
     dictionary->tail = NULL;
@@ -33,10 +33,10 @@ void dict_add(dict *dictionary, const char *key, const char *value) {
         }
         int key_length = (int)strlen(key) + 1;
         int value_length = (int)strlen(value) + 1;
-        dictionary->head = (pair *)malloc(sizeof(pair));
+        dictionary->head = malloc(sizeof(pair));
         assert(dictionary->head != NULL);
-        dictionary->head->key = (char *)malloc(key_length * sizeof(char));
-        dictionary->head->value = (char *)malloc(value_length * sizeof(char));
+        dictionary->head->key = malloc(key_length * sizeof(char));
+        dictionary->head->value = malloc(value_length * sizeof(char));
         assert(dictionary->head->key != NULL);
         strcpy(dictionary->head->key, key);
         assert(dictionary->head->value != NULL);

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -353,26 +353,11 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
     
     dict *package = dict_new();
     int safeID = repoID;
-    int longDesc = 0;
     
     char longDescription[1024];
     
     while (fgets(line, sizeof(line), file)) {
         if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0) {
-            if (longDesc && isspace(line[0])) {
-                int i = 0;
-                while (line[i] != '\0' && isspace(line[i])) {
-                    i++;
-                }
-                
-                strcat(longDescription, &line[i]);
-                
-                continue;
-            }
-            else {
-                longDesc = 0;
-            }
-            
             char *info = strtok(line, "\n");
             info = strtok(line, "\r");
             
@@ -392,7 +377,14 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
             }
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
-                longDesc = 1;
+                if (isspace(line[0])) {
+                    int i = 0;
+                    while (line[i] != '\0' && isspace(line[i])) {
+                        i++;
+                    }
+                    
+                    strcat(longDescription, &line[i]);
+                }
             }
         }
         else if (dict_get(package, "Package") != 0) {
@@ -479,25 +471,11 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
     
     dict *package = dict_new();
     int safeID = repoID;
-    int longDesc = 0;
     
     char longDescription[1024];
     
     while (fgets(line, sizeof(line), file)) {
         if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0 && strcmp(line, "\r\n") != 0 && strcmp(line, "\r") != 0) {
-            if (longDesc && isspace(line[0])) {
-                int i = 0;
-                while (line[i] != '\0' && isspace(line[i])) {
-                    i++;
-                }
-                strcat(longDescription, &line[i]);
-                
-                continue;
-            }
-            else {
-                longDesc = 0;
-            }
-            
             char *info = strtok(line, "\n");
             info = strtok(line, "\r");
             
@@ -517,7 +495,14 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
             }
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
-                longDesc = 1;
+                if (isspace(line[0])) {
+                    int i = 0;
+                    while (line[i] != '\0' && isspace(line[i])) {
+                        i++;
+                    }
+                    
+                    strcat(longDescription, &line[i]);
+                }
             }
         }
         else if (dict_get(package, "Package") != 0) {

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -358,7 +358,7 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
         return PARSEL_FILENOTFOUND;
     }
     
-    char line[256];
+    char line[2048];
     
     createTable(database, 1);
     sqlite3_exec(database, "BEGIN TRANSACTION", NULL, NULL, NULL);
@@ -367,7 +367,7 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
     int safeID = repoID;
     int longDesc = 0;
     
-    char longDescription[16384];
+    char longDescription[32768];
     
     while (fgets(line, sizeof(line), file)) {
         if (strlen(trim(line)) != 0) {
@@ -377,7 +377,7 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
                     i++;
                 }
                 
-                if (strlen(&line[i]) + strlen(longDescription) < 16384)
+                if (strlen(&line[i]) + strlen(longDescription) < 32768)
                     strcat(longDescription, &line[i]);
                 
                 continue;
@@ -479,7 +479,7 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
     if (file == NULL) {
         return PARSEL_FILENOTFOUND;
     }
-    char line[512];
+    char line[2048];
     
     createTable(database, 1);
     
@@ -492,7 +492,7 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
     int safeID = repoID;
     int longDesc = 0;
     
-    char longDescription[16384];
+    char longDescription[32768];
     
     while (fgets(line, sizeof(line), file)) {
         if (strlen(trim(line)) != 0) {
@@ -502,7 +502,7 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
                     i++;
                 }
                 
-                if (strlen(&line[i]) + strlen(longDescription) < 16384)
+                if (strlen(&line[i]) + strlen(longDescription) < 32768)
                     strcat(longDescription, &line[i]);
                                 
                 continue;

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -377,8 +377,10 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
                     i++;
                 }
                 
-                if (strlen(&line[i]) + strlen(longDescription) < 32768)
+                if (strlen(&line[i]) + strlen(longDescription) + 1 < 32768) {
                     strcat(longDescription, &line[i]);
+                    strcat(longDescription, "\n");
+                }
                 
                 continue;
             }
@@ -502,8 +504,10 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
                     i++;
                 }
                 
-                if (strlen(&line[i]) + strlen(longDescription) < 32768)
+                if (strlen(&line[i]) + strlen(longDescription) + 1 < 32768) {
                     strcat(longDescription, &line[i]);
+                    strcat(longDescription, "\n");
+                }
                                 
                 continue;
             }

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -9,6 +9,18 @@
 #include "parsel.h"
 #include "dict.h"
 #include <ctype.h>
+#include <stdlib.h>
+
+char *trim(char *s) {
+    size_t size = strlen(s);
+    if (!size)
+        return s;
+    char *end = s + size - 1;
+    while (end >= s && (*end == '\n' || *end == '\r' || isspace(*end)))
+        end--; // remove trailing space
+    *(end + 1) = '\0';
+    return s;
+}
 
 typedef char *multi_tok_t;
 
@@ -355,10 +367,10 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
     int safeID = repoID;
     int longDesc = 0;
     
-    char longDescription[1024];
+    char longDescription[16384];
     
     while (fgets(line, sizeof(line), file)) {
-        if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0) {
+        if (strlen(trim(line)) != 0) {
             if (longDesc && isspace(line[0])) {
                 int i = 0;
                 while (line[i] != '\0' && isspace(line[i])) {
@@ -384,12 +396,9 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
             if (key == NULL || value == NULL) { //y'all suck at maintaining repos, what do you do? make the package files by hand??
                 key = multi_tok(info, &s, ":");
                 value = multi_tok(NULL, &s, ":");
-                
-                dict_add(package, key, value);
             }
-            else {
-                dict_add(package, key, value);
-            }
+            printf("%s %s\n", key, value);
+            dict_add(package, key, value);
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
                 longDesc = 1;
@@ -481,10 +490,10 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
     int safeID = repoID;
     int longDesc = 0;
     
-    char longDescription[1024];
+    char longDescription[16384];
     
     while (fgets(line, sizeof(line), file)) {
-        if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0 && strcmp(line, "\r\n") != 0 && strcmp(line, "\r") != 0) {
+        if (strlen(trim(line)) != 0) {
             if (longDesc && isspace(line[0])) {
                 int i = 0;
                 while (line[i] != '\0' && isspace(line[i])) {
@@ -509,12 +518,8 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
             if (key == NULL || value == NULL) { //y'all suck at maintaining repos, what do you do? make the package files by hand??
                 key = multi_tok(info, &s, ":");
                 value = multi_tok(NULL, &s, ":");
-                
-                dict_add(package, key, value);
             }
-            else {
-                dict_add(package, key, value);
-            }
+            dict_add(package, key, value);
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
                 longDesc = 1;

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -353,11 +353,26 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
     
     dict *package = dict_new();
     int safeID = repoID;
+    int longDesc = 0;
     
     char longDescription[1024];
     
     while (fgets(line, sizeof(line), file)) {
         if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0) {
+            if (longDesc && isspace(line[0])) {
+                int i = 0;
+                while (line[i] != '\0' && isspace(line[i])) {
+                    i++;
+                }
+                
+                strcat(longDescription, &line[i]);
+                
+                continue;
+            }
+            else {
+                longDesc = 0;
+            }
+            
             char *info = strtok(line, "\n");
             info = strtok(line, "\r");
             
@@ -377,14 +392,7 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
             }
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
-                if (isspace(line[0])) {
-                    int i = 0;
-                    while (line[i] != '\0' && isspace(line[i])) {
-                        i++;
-                    }
-                    
-                    strcat(longDescription, &line[i]);
-                }
+                longDesc = 1;
             }
         }
         else if (dict_get(package, "Package") != 0) {
@@ -471,11 +479,25 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
     
     dict *package = dict_new();
     int safeID = repoID;
+    int longDesc = 0;
     
     char longDescription[1024];
     
     while (fgets(line, sizeof(line), file)) {
         if (strcmp(line, "\n") != 0 && strcmp(line, "") != 0 && strcmp(line, "\r\n") != 0 && strcmp(line, "\r") != 0) {
+            if (longDesc && isspace(line[0])) {
+                int i = 0;
+                while (line[i] != '\0' && isspace(line[i])) {
+                    i++;
+                }
+                strcat(longDescription, &line[i]);
+                
+                continue;
+            }
+            else {
+                longDesc = 0;
+            }
+            
             char *info = strtok(line, "\n");
             info = strtok(line, "\r");
             
@@ -495,14 +517,7 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
             }
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
-                if (isspace(line[0])) {
-                    int i = 0;
-                    while (line[i] != '\0' && isspace(line[i])) {
-                        i++;
-                    }
-                    
-                    strcat(longDescription, &line[i]);
-                }
+                longDesc = 1;
             }
         }
         else if (dict_get(package, "Package") != 0) {

--- a/Zebra/Parsel/parsel.c
+++ b/Zebra/Parsel/parsel.c
@@ -377,7 +377,8 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
                     i++;
                 }
                 
-                strcat(longDescription, &line[i]);
+                if (strlen(&line[i]) + strlen(longDescription) < 16384)
+                    strcat(longDescription, &line[i]);
                 
                 continue;
             }
@@ -397,7 +398,6 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
                 key = multi_tok(info, &s, ":");
                 value = multi_tok(NULL, &s, ":");
             }
-            printf("%s %s\n", key, value);
             dict_add(package, key, value);
             
             if (key != NULL && strcmp(key, "Description") == 0) { //Check for a long description
@@ -440,6 +440,8 @@ enum PARSEL_RETURN_TYPE importPackagesToDatabase(const char *path, sqlite3 *data
                     sqlite3_bind_text(insertStatement, 12, dict_get(package, "Author"), -1, SQLITE_TRANSIENT);
                     sqlite3_bind_text(insertStatement, 13, dict_get(package, "Filename"), -1, SQLITE_TRANSIENT);
                     sqlite3_bind_int(insertStatement, 14, repoID);
+                    if (longDescription[0] != '\0')
+                        longDescription[strlen(longDescription) - 1] = '\0';
                     sqlite3_step(insertStatement);
                 }
                 else {
@@ -499,8 +501,10 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
                 while (line[i] != '\0' && isspace(line[i])) {
                     i++;
                 }
-                strcat(longDescription, &line[i]);
                 
+                if (strlen(&line[i]) + strlen(longDescription) < 16384)
+                    strcat(longDescription, &line[i]);
+                                
                 continue;
             }
             else {
@@ -560,6 +564,8 @@ enum PARSEL_RETURN_TYPE updatePackagesInDatabase(const char *path, sqlite3 *data
                 sqlite3_bind_text(insertStatement, 12, dict_get(package, "Provides"), -1, SQLITE_TRANSIENT);
                 sqlite3_bind_text(insertStatement, 13, dict_get(package, "Filename"), -1, SQLITE_TRANSIENT);
                 sqlite3_bind_int(insertStatement, 14, repoID);
+                if (longDescription[0] != '\0')
+                    longDescription[strlen(longDescription) - 1] = '\0';
                 sqlite3_step(insertStatement);
             }
             else {


### PR DESCRIPTION
This will fix startup crash due to incorrect reading of package's long description.