### PR TITLE
[Depictions] Send the locale language and Inform the repos that we support payments

### DIFF
--- a/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -126,6 +126,8 @@
     [request setValue:version forHTTPHeaderField:@"X-Firmware"];
     [request setValue:udid forHTTPHeaderField:@"X-Unique-ID"];
     [request setValue:machineIdentifier forHTTPHeaderField:@"X-Machine"];
+    [request setValue:@"API" forHTTPHeaderField:@"Payment-Provider"];
+    [request setValue:[[NSLocale preferredLanguages] firstObject] forHTTPHeaderField:@"Accept-Language"];
     
     [webView loadRequest:request];
 //    [webView loadFileURL:url allowingReadAccessToURL:[url URLByDeletingLastPathComponent]];

--- a/Zebra/Packages/Helpers/ZBPackage.h
+++ b/Zebra/Packages/Helpers/ZBPackage.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) ZBRepo *repo;
 @property (nonatomic, strong) NSString *filename;
 @property (nonatomic, strong) NSString *iconPath;
+@property (nonatomic, strong) NSString *origBundleID;
 @property BOOL sileoDownload;
 
 + (NSArray *)filesInstalled:(NSString *)packageID;

--- a/Zebra/Repos/Controllers/ZBRepoPurchasedPackagesTableViewController.m
+++ b/Zebra/Repos/Controllers/ZBRepoPurchasedPackagesTableViewController.m
@@ -77,7 +77,12 @@
         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
         //self.packages = json[@"items"];
         [self.packages removeAllObjects];
-        self.packages = (NSMutableArray<ZBPackage *> *) [self.databaseManager purchasedPackages: json[@"items"]];
+        //Make package ids lowercase so we dont miss any
+        NSMutableArray *loweredPackages = [NSMutableArray new];
+        for(NSString *name in json[@"items"]){
+            [loweredPackages addObject:[name lowercaseString]];
+        }
+        self.packages = (NSMutableArray<ZBPackage *> *) [self.databaseManager purchasedPackages: loweredPackages];
         if(json[@"user"]){
             if([json valueForKeyPath:@"user.name"]){
                 self.userName = [json valueForKeyPath:@"user.name"];


### PR DESCRIPTION
This PR includes the following:
- Language Header in depictions
- Payment-Provider header with the value of API (`Payment_Provider: API`) to inform the repo that we support payments without needing to be redirected from the webview
- You can now view Gesto in purchases, need to fix purchasing it.