### PR TITLE
Start URL Blacklist for Non-Repo URLs

### DIFF
--- a/Zebra/Repos/Controllers/ZBRepoListTableViewController.m
+++ b/Zebra/Repos/Controllers/ZBRepoListTableViewController.m
@@ -97,11 +97,14 @@
 - (void)checkClipboard {
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
     NSURL *url = [NSURL URLWithString:pasteboard.string];
+    NSArray *urlBlacklist = @[@"youtube.com", @"google.com", @"reddit.com", @"twitter.com", @"facebook.com", @"imgur.com", @"discord.com", @"discord.gg"];
     
     if ((url && url.scheme && url.host)) {
         if ([[url scheme] isEqual:@"https"] || [[url scheme] isEqual:@"http"]) {
             if (!askedToAddFromClipboard || ![lastPaste isEqualToString: pasteboard.string]) {
-                [self showAddRepoFromClipboardAlert:url];
+                if (![urlBlacklist containsObject:url.host]) {
+                    [self showAddRepoFromClipboardAlert:url];
+                }
             }
             askedToAddFromClipboard = YES;
             lastPaste = pasteboard.string;


### PR DESCRIPTION
I started a URL blacklist for the add repo from clipboard function. Pretty minimal for now but most common link hosts I could think of. Tested it on the sim not on device but hoping should work the same!