### PR TITLE
Start Repo URL Blacklist On Clipboard Manager

### DIFF
--- a/Zebra/Repos/Controllers/ZBRepoListTableViewController.m
+++ b/Zebra/Repos/Controllers/ZBRepoListTableViewController.m
@@ -88,11 +88,14 @@
 - (void)checkClipboard {
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
     NSURL *url = [NSURL URLWithString:pasteboard.string];
+    NSArray *urlBlacklist = @[@"youtube.com", @"google.com", @"reddit.com", @"twitter.com", @"facebook.com", @"imgur.com", @"discord.com", @"discord.gg"];
     
     if ((url && url.scheme && url.host)) {
         if ([[url scheme] isEqual:@"https"] || [[url scheme] isEqual:@"http"]) {
-            if (!askedToAddFromClipboard || ![lastPaste isEqualToString:pasteboard.string]) {
-                [self showAddRepoFromClipboardAlert:url];
+            if (!askedToAddFromClipboard || ![lastPaste isEqualToString: pasteboard.string]) {
+                if (![urlBlacklist containsObject:url.host]) {
+                    [self showAddRepoFromClipboardAlert:url];
+                }
             }
             askedToAddFromClipboard = YES;
             lastPaste = pasteboard.string;


### PR DESCRIPTION
Fixing PR because old was from a fork that was outdated. Sorry for the dupe!

This basically starts a blacklist of common social media, media links that people may have saved!