### PR TITLE
Fix webview scrolling in depictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ after-stage::
 	ldid -SZebra/Zebra.entitlements $(THEOS_STAGING_DIR)/Applications/Zebra.app/Zebra
 
 after-install::
-	install.exec "killall \"Cr4shed\"" || true
+	install.exec "killall \"Zebra\"" || true

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ after-stage::
 	ldid -S $(THEOS_STAGING_DIR)/Applications/Zebra.app/Zebra
 	ldid -S $(THEOS_STAGING_DIR)/Applications/Zebra.app/Frameworks/SDWebImage.framework/SDWebImage
 	ldid -SZebra/Zebra.entitlements $(THEOS_STAGING_DIR)/Applications/Zebra.app/Zebra
+
+after-install::
+	install.exec "killall \"Cr4shed\"" || true

--- a/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -117,8 +117,6 @@ enum ZBPackageInfoOrder {
     webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 600) configuration:configuration];
     webView.translatesAutoresizingMaskIntoConstraints = NO;
     
-    [self.view addSubview:webView];
-    
     progressView = [[UIProgressView alloc] initWithFrame:CGRectMake(0,0,0,0)];
     progressView.translatesAutoresizingMaskIntoConstraints = NO;
     


### PR DESCRIPTION
Previously, the WKWebView in depictions would scroll in its own WKScrollView while loading, instead of scrolling the entire table view. This was due to some faulty logic where the webview was added as a subview of the tableview, **and** as the footer. This fixes that issue (and also gets theos to kill Zebra on install).