### PR TITLE
Trim extra whitespace from search queries.

### DIFF
--- a/Zebra/Tabs/Search/ZBSearchViewController.m
+++ b/Zebra/Tabs/Search/ZBSearchViewController.m
@@ -148,10 +148,9 @@ enum ZBSearchSection {
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar {
     [searchBar resignFirstResponder];
     NSString *query = [searchBar text];
-    
+
     // Make sure the query has no extra whitespace
     query = [query stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-
     if (query.length <= 1) {
         [ZBAppDelegate sendErrorToTabController:@"This search query is too short for the full search, please use a longer query."];
         return;

--- a/Zebra/Tabs/Search/ZBSearchViewController.m
+++ b/Zebra/Tabs/Search/ZBSearchViewController.m
@@ -148,6 +148,10 @@ enum ZBSearchSection {
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar {
     [searchBar resignFirstResponder];
     NSString *query = [searchBar text];
+    
+    // Make sure the query has no extra whitespace
+    query = [query stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
     if (query.length <= 1) {
         [ZBAppDelegate sendErrorToTabController:@"This search query is too short for the full search, please use a longer query."];
         return;


### PR DESCRIPTION
Noticed that queries wouldn't show up when having a space before or after the query.