### PR TITLE
Refactor ZBQueue for Localization support

### DIFF
--- a/Zebra/Queue/ZBQueue.h
+++ b/Zebra/Queue/ZBQueue.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ZBQueue : NSObject
-@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray *> *managedQueue;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSMutableArray *> *managedQueue;
 @property (nonatomic, strong) NSMutableArray<NSArray *> *failedDepQueue;
 @property (nonatomic, strong) NSMutableArray<NSArray *> *failedConQueue;
 @property(assign) BOOL useIcon;
@@ -31,12 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)markPackageAsFailed:(ZBPackage *)package forConflicts:(ZBPackage *)conflict conflictionType:(int)type;
 - (void)removePackage:(ZBPackage *)package fromQueue:(ZBQueueType)queue;
 - (NSArray *)tasks:(NSArray <NSDictionary <NSString*, NSString *> *> *)debs;
-- (int)numberOfPackagesForQueue:(NSString *)queue;
+- (int)numberOfPackagesForQueue:(ZBQueueType)queue;
 - (nullable NSMutableArray <ZBPackage *> *)packagesRequiredBy:(ZBPackage *)package;
 - (nullable ZBPackage *)packageReplacedBy:(ZBPackage *)package;
 - (ZBPackage *)packageInQueue:(ZBQueueType)queue atIndex:(NSInteger)index;
 - (void)clearQueue;
-- (NSArray *)actionsToPerform;
+- (NSArray<NSNumber *> *)actionsToPerform;
 - (NSMutableArray *)queueArray:(ZBQueueType)queue;
 - (BOOL)hasObjects;
 - (BOOL)containsPackage:(ZBPackage *)package;
@@ -46,7 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)needsHyena;
 - (NSString *)queueToKey:(ZBQueueType)queue;
 - (NSString *)queueToKeyDisplayed:(ZBQueueType)queue;
-- (ZBQueueType)keyToQueue:(NSString *)key;
 - (ZBQueueType)queueStatusForPackage:(ZBPackage *)package;
 - (BOOL)hasErrors;
 @end

--- a/Zebra/Queue/ZBQueueType.h
+++ b/Zebra/Queue/ZBQueueType.h
@@ -9,13 +9,23 @@
 #ifndef ZBQueueType_h
 #define ZBQueueType_h
 
+
 typedef enum {
-    ZBQueueTypeInstall      = 1 << 0,
-    ZBQueueTypeRemove       = 1 << 1,
-    ZBQueueTypeUpgrade      = 1 << 2,
-    ZBQueueTypeReinstall    = 1 << 3,
-    ZBQueueTypeSelectable   = 1 << 4,
-    ZBQueueTypeClear        = 1 << 5
+    ZBQueueTypeUnknown                = 0,
+
+    ZBQueueTypeInstall                = 1 << 0,
+    ZBQueueTypeRemove                 = 1 << 1,
+    ZBQueueTypeUpgrade                = 1 << 2,
+    ZBQueueTypeReinstall              = 1 << 3,
+#define ZBQueueTypeIsPartOfManagedQueue(x) (x >= ZBQueueTypeInstall && x <= ZBQueueTypeReinstall)
+
+    ZBQueueTypeSelectable             = 1 << 4,
+    ZBQueueTypeClear                  = 1 << 5,
+#define ZBQueueTypeIsAction(x) (x >= ZBQueueTypeInstall && x <= ZBQueueTypeClear)
+
+    ZBQueueTypeUnresolvedDependencies = 1 << 6,
+    ZBQueueTypeConflictions           = 1 << 7,
 } ZBQueueType;
+
 
 #endif /* ZBQueueType_h */

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActionsManager.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActionsManager.m
@@ -95,7 +95,7 @@
                 if (q == ZBQueueTypeSelectable) {
                     [self selectVersionForPackage:package indexPath:indexPath viewController:vc parent:parent];
                 } else if (q == ZBQueueTypeClear) {
-                    [queue removePackage:package fromQueue:0];
+                    [queue removePackage:package fromQueue:ZBQueueTypeUnknown];
                 } else {
                     [queue addPackage:package toQueue:q];
                 }
@@ -118,7 +118,7 @@
                 } else if (q == ZBQueueTypeSelectable) {
                     [self selectVersionForPackage:package indexPath:nil viewController:vc parent:parent];
                 } else if (q == ZBQueueTypeClear) {
-                    [queue removePackage:package fromQueue:0];
+                    [queue removePackage:package fromQueue:ZBQueueTypeUnknown];
                 } else {
                     [queue addPackage:package toQueue:q];
                 }
@@ -133,7 +133,7 @@
                 } else if (q == ZBQueueTypeSelectable) {
                     [self selectVersionForPackage:package indexPath:nil viewController:vc parent:parent];
                 } else if (q == ZBQueueTypeClear) {
-                    [queue removePackage:package fromQueue:0];
+                    [queue removePackage:package fromQueue:ZBQueueTypeUnknown];
                 } else {
                     [queue addPackage:package toQueue:q];
                     [self presentQueue:vc parent:parent];
@@ -150,7 +150,7 @@
     NSUInteger possibleActions = [package possibleActions];
     ZBQueue *queue = [ZBQueue sharedInstance];
     
-    for (ZBQueueType q = ZBQueueTypeInstall; q <= ZBQueueTypeClear; q <<= 1) {
+    for (ZBQueueType q = ZBQueueTypeInstall; ZBQueueTypeIsAction(q); q <<= 1) {
         if ([self canHaveAction:possibleActions forPackage:package queue:q]) {
             NSString *title = type == 0 ? [queue queueToKeyDisplayed:q] : [queue queueToKey:q];
             void (^handler)(void) = [self getHandler:type package:package indexPath:indexPath queue:q to:queue viewController:vc parent:parent completion:completion];

--- a/Zebra/Tabs/ZBTabBarController.m
+++ b/Zebra/Tabs/ZBTabBarController.m
@@ -169,9 +169,10 @@
 
 - (void)updateQueueBarData {
     int totalPackages = 0;
-    NSArray *actions = [[ZBQueue sharedInstance] actionsToPerform];
-    for (NSString *string in actions) {
-        totalPackages += [[ZBQueue sharedInstance] numberOfPackagesForQueue:string];
+    NSArray<NSNumber *> *actions = [[ZBQueue sharedInstance] actionsToPerform];
+    for (NSNumber *key in actions) {
+        ZBQueueType queue = key.intValue;
+        totalPackages += [[ZBQueue sharedInstance] numberOfPackagesForQueue:queue];
     }
     if (totalPackages == 0) {
         [[ZBAppDelegate tabBarController] dismissPopupBarAnimated:YES completion:nil];


### PR DESCRIPTION
ZBQueue was using the strings "Unresolved Dependencies" and
"Conflictions" to capture state, which got mixed in with string
representations of ZBQueueType. These strings were also used in the
UI, which made Localization impossible.

I added ZBQueueTypeUnresolvedDependencies and ZBQueueTypeConflictions
as new ZBQueueTypes, and which got rid of the need to use strings to
capture state. Now these support Localization, plus it's a bit cleaner
and faster since it uses ZBQueueType now instead of comparing strings.

I also went ahead and added ZBQueueTypeUnknown and replaced that
wherever "0" was used, so it's a bit better documented. Plus some
macros for looping ZBQueueTypes. And removed -[ZBQueue keyToQueue].

Related to #166 and #392 