### PR TITLE
Use NSNumber for key in -[ZBQueue managedQueue]

### DIFF
--- a/Zebra/Queue/ZBQueue.h
+++ b/Zebra/Queue/ZBQueue.h
@@ -24,11 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 //- (void)removePackage:(ZBPackage *)package inQueue:(ZBQueueType)queue;
 - (NSArray *)tasksToPerform:(NSArray <NSDictionary <NSString*, NSString *> *> *)debs;
 - (NSMutableArray *)queueFromType:(ZBQueueType)queue;
-- (ZBQueueType)queueTypeFromKey:(NSString *)key;
-- (NSString *)keyFromQueueType:(ZBQueueType)queue;
-- (NSArray *)actionsToPerform;
+- (NSArray<NSNumber *> *)actionsToPerform;
 - (NSString *)displayableNameForQueueType:(ZBQueueType)queue useIcon:(BOOL)useIcon;
-- (int)numberOfPackagesInQueueKey:(NSString *)queue;
 - (int)numberOfPackagesInQueue:(ZBQueueType)queue;
 - (BOOL)needsToDownloadPackages;
 - (NSArray *)packagesToDownload;

--- a/Zebra/Queue/ZBQueueViewController.m
+++ b/Zebra/Queue/ZBQueueViewController.m
@@ -115,8 +115,7 @@
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    ZBQueueType action;
-    [[[queue actionsToPerform] objectAtIndex:section] getValue:&action];
+    ZBQueueType action = [queue actionsToPerform][section].intValue;
     if (action == ZBQueueTypeInstall || action == ZBQueueTypeReinstall || action == ZBQueueTypeUpgrade || action == ZBQueueTypeDowngrade) {
         return [NSString stringWithFormat:@"%@ (Download Size: %@)", [queue displayableNameForQueueType:action useIcon:false], [queue downloadSizeForQueue:action]];
     }

--- a/Zebra/Tabs/Packages/Views/ZBPackageTableViewCell.m
+++ b/Zebra/Tabs/Packages/Views/ZBPackageTableViewCell.m
@@ -78,7 +78,7 @@
 - (void)updateQueueStatus:(ZBPackage *)package {
 //    ZBQueueType queue = [[ZBQueue sharedQueue] queueStatusForPackage:package];
 //    if (queue) {
-//        NSString *status = [[ZBQueue sharedQueue] keyFromQueueType:queue];
+//        NSString *status = [[ZBQueue sharedQueue] displayableNameForQueueType:queue useIcon:false];
 //        self.queueStatusLabel.hidden = NO;
 //        self.queueStatusLabel.text = [NSString stringWithFormat:@" %@ ", status];
 //        self.queueStatusLabel.backgroundColor = [ZBPackageActionsManager colorForAction:queue];


### PR DESCRIPTION
I also changed some other places in the codebase to make
this more consistent (e.g. remove NSValue stuff).

I also simplified some code in ZBQueue.m, and removed
the stringkey-to-ZBQueueType conversion methods.

Related to #393 and #394