### PR TITLE
[Localization] Cleanup ZBPackageDepictionViewController

### DIFF
--- a/Zebra/Base.lproj/Localizable.strings
+++ b/Zebra/Base.lproj/Localizable.strings
@@ -141,12 +141,14 @@
 "Available Upgrades" = "Available Upgrades";
 "Ignored Upgrades" = "Ignored Upgrades";
 "Recent" = "Recent";
+"Repo" = "Repo";
 "Installed Files" = "Installed Files";
 "Modify" = "Modify";
 "Authenticate to initiate purchase." = "Authenticate to initiate purchase.";
 "Please relogin your account that is used to purchase this package (Possibly %@)" = "Please relogin your account that is used to purchase this package (Possibly %@)";
 "More by this Developer" = "More by this Developer";
 "Installed Version" = "Installed Version";
+"Installed Size" = "Installed Size";
 
 "Add to Wish List" = "Add to Wish List";
 "Remove from Wish List" = "Remove from Wish List";

--- a/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -37,9 +37,10 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
     ZBPackageInfoMoreBy,
     ZBPackageInfoInstalledFiles
 };
+static const NSUInteger ZBPackageInfoOrderCount = 8;
 
 @interface ZBPackageDepictionViewController () {
-    NSMutableDictionary *infos;
+    NSMutableDictionary<NSNumber *, NSString *> *infos;
     UIProgressView *progressView;
     WKWebView *webView;
     BOOL presented;
@@ -602,29 +603,6 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
 
 #pragma mark TableView
 
-- (CGFloat)rowHeight {
-    return 45;
-}
-
-- (NSArray *)packageInfoOrder {
-    static NSArray *packageInfoOrder = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // FIXME: Refactor this so it supports localization.
-        packageInfoOrder = @[
-                             @"PackageID",
-                             @"Author",
-                             @"Version",
-                             @"Size",
-                             @"Repo",
-                             @"WishList",
-                             @"MoreBy",
-                             @"Installed Files"
-                             ];
-    });
-    return packageInfoOrder;
-}
-
 - (void)readIcon:(ZBPackage *)package {
     self.packageName.text = package.name;
     self.packageName.textColor = [UIColor cellPrimaryTextColor];
@@ -650,25 +628,25 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
 
 - (void)readPackageID:(ZBPackage *)package {
     if (package.identifier) {
-        infos[@"PackageID"] = package.identifier;
+        infos[@(ZBPackageInfoID)] = package.identifier;
     } else {
-        [infos removeObjectForKey:@"PackageID"];
+        [infos removeObjectForKey:@(ZBPackageInfoID)];
     }
 }
 
 - (void)setMoreByText:(ZBPackage *)package {
     if (package.author) {
-        infos[@"MoreBy"] = NSLocalizedString(@"More by this Developer", @"");
+        infos[@(ZBPackageInfoMoreBy)] = NSLocalizedString(@"More by this Developer", @"");
     } else {
-        [infos removeObjectForKey:@"MoreBy"];
+        [infos removeObjectForKey:@(ZBPackageInfoMoreBy)];
     }
 }
 
 - (void)readVersion:(ZBPackage *)package {
     if (![package isInstalled:NO] || [package installedVersion] == nil) {
-        infos[@"Version"] = package.version;
+        infos[@(ZBPackageInfoVersion)] = package.version;
     } else {
-        infos[@"Version"] = [NSString stringWithFormat:@"%@ (Installed Version: %@)", package.version, [package installedVersion]];
+        infos[@(ZBPackageInfoVersion)] = [NSString stringWithFormat:@"%@ (%@: %@)", package.version, NSLocalizedString(@"Installed Version", @""), [package installedVersion]];
     }
 }
 
@@ -676,37 +654,37 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
     NSString *size = [package size];
     NSString *installedSize = [package installedSize];
     if (size && installedSize) {
-        infos[@"Size"] = [NSString stringWithFormat:@"%@ (Installed Size: %@)", size, installedSize];
+        infos[@(ZBPackageInfoSize)] = [NSString stringWithFormat:@"%@ (%@: %@)", size, NSLocalizedString(@"Installed Size", @""), installedSize];
     } else if (size) {
-        infos[@"Size"] = size;
+        infos[@(ZBPackageInfoSize)] = size;
     } else {
-        [infos removeObjectForKey:@"Size"];
+        [infos removeObjectForKey:@(ZBPackageInfoSize)];
     }
 }
 
 - (void)readRepo:(ZBPackage *)package {
     NSString *repoName = [[package repo] origin];
     if (repoName) {
-        infos[@"Repo"] = repoName;
+        infos[@(ZBPackageInfoRepo)] = repoName;
     } else {
-        [infos removeObjectForKey:@"Repo"];
+        [infos removeObjectForKey:@(ZBPackageInfoRepo)];
     }
 }
 
 - (void)readFiles:(ZBPackage *)package {
     if ([package isInstalled:NO]) {
-        infos[@"Installed Files"] = @"";
+        infos[@(ZBPackageInfoInstalledFiles)] = @"";
     } else {
-        [infos removeObjectForKey:@"Installed Files"];
+        [infos removeObjectForKey:@(ZBPackageInfoInstalledFiles)];
     }
 }
 
 - (void)readAuthor:(ZBPackage *)package {
     NSString *authorName = [package author];
     if (authorName) {
-        infos[@"Author"] = [self stripEmailFromAuthor];
+        infos[@(ZBPackageInfoAuthor)] = [self stripEmailFromAuthor];
     } else {
-        [infos removeObjectForKey:@"Author"];
+        [infos removeObjectForKey:@(ZBPackageInfoAuthor)];
     }
 }
 
@@ -719,7 +697,7 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
     [self readFiles:package];
     [self readPackageID:package];
     [self setMoreByText:package];
-    infos[@"WishList"] = @"";
+    infos[@(ZBPackageInfoWishList)] = @"";
     [self.tableView reloadData];
 }
 
@@ -775,39 +753,31 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
 #pragma mark - UITableViewDataSource
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSString *property = [self packageInfoOrder][indexPath.row];
-    NSString *value = infos[property];
-    return value ? [self rowHeight] : 0;
+    return infos[@(indexPath.row)] == nil ? 0 : 45;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *simpleTableIdentifier = @"PackageInfoTableViewCell";
     
     UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:simpleTableIdentifier];
-    
-    NSString *property = [self packageInfoOrder][indexPath.row];
-    NSString *value = infos[property];
-    
-    ZBPackageInfoOrder row = indexPath.row;
+
+    NSString *value = infos[@(indexPath.row)];
     
     if (cell == nil) {
-        if (row == ZBPackageInfoSize || row == ZBPackageInfoVersion || row == ZBPackageInfoRepo) {
+        if (indexPath.row == ZBPackageInfoSize || indexPath.row == ZBPackageInfoVersion || indexPath.row == ZBPackageInfoRepo) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:simpleTableIdentifier];
         } else {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:simpleTableIdentifier];
         }
     }
+
+    cell.textLabel.text = nil;
     cell.textLabel.textColor = [UIColor cellPrimaryTextColor];
+
+    cell.detailTextLabel.text = nil;
+    cell.detailTextLabel.textColor = [UIColor cellSecondaryTextColor];
     
-    switch (row) {
-        case ZBPackageInfoInstalledFiles:
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.textLabel.text = property;
-            break;
-        case ZBPackageInfoMoreBy:
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.textLabel.text = value;
-            break;
+    switch ((ZBPackageInfoOrder)indexPath.row) {
         case ZBPackageInfoID:
             cell.textLabel.text = value;
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -816,25 +786,35 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
             cell.textLabel.text = value;
             cell.accessoryType = self.authorEmail ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellSelectionStyleNone;
             break;
+        case ZBPackageInfoVersion:
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.textLabel.text = NSLocalizedString(@"Version", @"");
+            cell.detailTextLabel.text = value;
+            break;
+        case ZBPackageInfoSize:
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.textLabel.text = NSLocalizedString(@"Size", @"");
+            cell.detailTextLabel.text = value;
+            break;
+        case ZBPackageInfoRepo:
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.textLabel.text = NSLocalizedString(@"Repo", @"");
+            cell.detailTextLabel.text = value;
+            break;
         case ZBPackageInfoWishList: {
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
             BOOL inWishList = [[defaults objectForKey:wishListKey] containsObject:package.identifier];
             cell.textLabel.text = NSLocalizedString(inWishList ? @"Remove from Wish List" : @"Add to Wish List", @"");
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             break;
-        }
-        default: {
-            cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            if (value) {
-                cell.textLabel.text = property;
-                cell.detailTextLabel.text = value;
-                cell.detailTextLabel.textColor = [UIColor cellSecondaryTextColor];
-            } else {
-                cell.textLabel.text = nil;
-                cell.detailTextLabel.text = nil;
-            }
+        } case ZBPackageInfoMoreBy:
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.textLabel.text = value;
             break;
-        }
+        case ZBPackageInfoInstalledFiles:
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.textLabel.text = NSLocalizedString(@"Installed Files", @"");
+            break;
     }
     return cell;
 }
@@ -860,31 +840,23 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return [self packageInfoOrder].count;
+    assert(section == 0);
+    return ZBPackageInfoOrderCount;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     ZBPackageInfoOrder row = indexPath.row;
     switch (row) {
         case ZBPackageInfoID:
-        case ZBPackageInfoRepo:
-        case ZBPackageInfoVersion:
-        case ZBPackageInfoSize:
-            break;
-        case ZBPackageInfoInstalledFiles: {
-            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-            ZBInstalledFilesTableViewController *filesController = [storyboard instantiateViewControllerWithIdentifier:@"installedFilesController"];
-            filesController.navigationItem.title = @"Installed Files";
-            [filesController setPackage:package];
-            [[self navigationController] pushViewController:filesController animated:YES];
-            break;
-        }
-        case ZBPackageInfoMoreBy:
-            [self performSegueWithIdentifier:@"seguePackageDepictionToMorePackages" sender:[self stripEmailFromAuthor]];
             break;
         case ZBPackageInfoAuthor:
-            if (self.authorEmail)
+            if (self.authorEmail) {
                 [self sendEmailToDeveloper];
+            }
+            break;
+        case ZBPackageInfoVersion:
+        case ZBPackageInfoSize:
+        case ZBPackageInfoRepo:
             break;
         case ZBPackageInfoWishList: {
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -898,6 +870,16 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
                 [defaults setObject:wishList forKey:wishListKey];
             }
             [tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:row inSection:0]] withRowAnimation:UITableViewRowAnimationNone];
+            break;
+        } case ZBPackageInfoMoreBy:
+            [self performSegueWithIdentifier:@"seguePackageDepictionToMorePackages" sender:[self stripEmailFromAuthor]];
+            break;
+        case ZBPackageInfoInstalledFiles: {
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+            ZBInstalledFilesTableViewController *filesController = [storyboard instantiateViewControllerWithIdentifier:@"installedFilesController"];
+            filesController.navigationItem.title = NSLocalizedString(@"Installed Files", @"");
+            [filesController setPackage:package];
+            [[self navigationController] pushViewController:filesController animated:YES];
             break;
         }
     }


### PR DESCRIPTION
Got rid of the string keys in `infos`, we now use the enum instead.
This class could be cleaned up a bit more...

Fixes #407 