### PR TITLE
Possible deprecation warning fix for theos package version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include $(THEOS)/makefiles/common.mk
 include $(THEOS_MAKE_PATH)/null.mk
 
 all::
-	xcodebuild CODE_SIGN_IDENTITY="" AD_HOC_CODE_SIGNING_ALLOWED=YES -scheme Zebra archive -archivePath Zebra.xcarchive PACKAGE_VERSION='@\"$(THEOS_PACKAGE_VERSION)\"' | xcpretty && exit ${PIPESTATUS[0]}
+	xcodebuild CODE_SIGN_IDENTITY="" AD_HOC_CODE_SIGNING_ALLOWED=YES -scheme Zebra archive -archivePath Zebra.xcarchive PACKAGE_VERSION='@\"$(THEOS_PACKAGE_BASE_VERSION)-$(VERSION.INC_BUILD_NUMBER)\"' | xcpretty && exit ${PIPESTATUS[0]}
 
 after-stage::
 	mv Zebra.xcarchive/Products/Applications $(THEOS_STAGING_DIR)/Applications


### PR DESCRIPTION
After the previous PR, I started searching for a possible fix for this as you wanted the build number along the package version, so I found a thread in reddit where /u/DHowett (the original dev for theos) explained the different Packge Version Variables used by theos and he was recommending this way to have an incrementing build number along with the base version in order to avoid the deprecation warning. Hope it will be useful. I personally tested it and it succesfully compiles different debs with incrementing build numbers.

P.S. Sorry if I am creating stupid PR's. Keep up the good work.