### PR TITLE
[Search] Set keyboardDismissMode to OnDrag

### DIFF
--- a/Zebra/Tabs/Search/ZBSearchViewController.m
+++ b/Zebra/Tabs/Search/ZBSearchViewController.m
@@ -72,7 +72,7 @@ enum ZBSearchSection {
         self.tableView.tableHeaderView = searchController.searchBar;
     }
     self.tableView.tableFooterView = [UIView new];
-    
+    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     [self.tableView registerNib:[UINib nibWithNibName:@"ZBPackageTableViewCell" bundle:nil] forCellReuseIdentifier:@"packageTableViewCell"];
     
     previewing = [self registerForPreviewingWithDelegate:self sourceView:self.tableView];


### PR DESCRIPTION
Small suggestion for the SearchVC scroll behaviour.

Indeed, this will resign the first responder when the user starts scrolling on the search page.

This change follows the system apps behaviour(settings, contacts, ...) and is especially useful with the "Live Search" setting.