### PR TITLE
[Scripts] firmware.sh should run from libexec root if available

### DIFF
--- a/layout/usr/libexec/zebra/startup
+++ b/layout/usr/libexec/zebra/startup
@@ -7,7 +7,11 @@ if [ ! -d "/chimera " ] && [ ! -d "/electra" ]; then
       cache=
   fi
 
-  /usr/libexec/zebra/firmware.sh
+  if [[ -x "/usr/libexec/firmware.sh" ]]; then
+     /usr/libexec/firmware.sh
+  else
+     /usr/libexec/zebra/firmware.sh
+  fi
 
   debs=(/var/mobile/Documents/xyz.willy.Zebra/debs*.deb)
   if [[ ${#debs[@]} -ne 0 && -f ${debs[0]} ]]; then


### PR DESCRIPTION
This is a somewhat essential fix for the future. Some modern jailbreaks bundle firmware.sh in another package (e.g. darwintools on checkra1n), and I suspect this will be the future. In the case that the jailbreak's bundled firmware.sh has changed, zebra would continue running the old firmware.sh you have bundled. To combat this, I've made the startup script execute firmware.sh from `/usr/libexec/zebra/` only if the script cannot be found in the libexec root. Would likely solve #1008 