### PR TITLE
[Settings] Fix searching for author to filter

### DIFF
--- a/Zebra/Tabs/Home/Settings/Filters/ZBAuthorSelectorTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Filters/ZBAuthorSelectorTableViewController.m
@@ -17,6 +17,7 @@
     ZBDatabaseManager *databaseManager;
     NSArray <NSArray <NSString *> *> *authors;
     NSMutableDictionary <NSString *, NSString *> *selectedAuthors;
+    NSMutableArray *newSelectedAuthors;
     BOOL shouldPerformSearching;
 }
 @end
@@ -32,6 +33,7 @@
     
     if (self) {
         authors = @[];
+        newSelectedAuthors = [NSMutableArray new];
         selectedAuthors = [[ZBSettings blockedAuthors] mutableCopy];
     }
     
@@ -99,7 +101,7 @@
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") style:UIBarButtonItemStylePlain target:self action:@selector(goodbye)];
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Add", @"") style:UIBarButtonItemStyleDone target:self action:@selector(addAuthors)];
-    self.navigationItem.rightBarButtonItem.enabled = [[selectedAuthors allKeys] count];
+    self.navigationItem.rightBarButtonItem.enabled = [newSelectedAuthors count];
 }
 
 - (void)addAuthors {
@@ -163,7 +165,6 @@
     self->shouldPerformSearching = YES;
     
     [self updateSearchResultsForSearchController:searchController];
-    [self.searchController setActive:false];
 }
 
 #pragma mark - Table View Data Source
@@ -211,9 +212,11 @@
     NSArray *authorDetail = authors[indexPath.row];
     if ([selectedAuthors objectForKey:authorDetail[1]]) {
         [selectedAuthors removeObjectForKey:authorDetail[1]];
+        [newSelectedAuthors removeObject:authorDetail[1]];
     }
     else {
         [selectedAuthors setObject:authorDetail[0] forKey:authorDetail[1]];
+        [newSelectedAuthors addObject:authorDetail[1]];
     }
     
     [[self tableView] reloadData];

--- a/Zebra/Tabs/Home/Settings/Filters/ZBFilterSettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Filters/ZBFilterSettingsTableViewController.m
@@ -258,7 +258,6 @@
                 [self presentViewController:nav animated:true completion:nil];
             }
             break;
-            break;
         case 3:
             break;
     }


### PR DESCRIPTION
I found a few small bug, with filtering author.
- When we press "search", the result and search bar placeholder  will disappear.
- When you have one or more filtered author and when you try to search, you can press "add". (This should be gray out when you haven't select any)

This PR will fix both of those.