### PR TITLE
[Localization] Add and remove localization strings

### DIFF
--- a/Zebra/Base.lproj/Localizable.strings
+++ b/Zebra/Base.lproj/Localizable.strings
@@ -70,7 +70,9 @@
 "Text" = "Text";
 "Icon" = "Icon";
 "Finish Automatically" = "Finish Automatically";
-"Hide UDID" = "Hide UDID";
+
+// "Hide UDID" = "Hide UDID";
+
 "Automatic Refresh" = "Automatic Refresh";
 
 // Accent Colors
@@ -141,8 +143,8 @@
 "No Storefronts Available" = "No Storefronts Available";
 "Could not authenticate" = "Could not authenticate";
 "Could not complete purchase" = "Could not complete purchase";
-"Could not complete purchase, no payment secret was found" = "Could not complete purchase, no payment secret was found";
 "No packages purchased" = "No packages purchased";
+"Logged in as %@" = "Logged in as %@";
 "Logged in as %@ (%@)" = "Logged in as %@ (%@)";
 
 // Sources

--- a/Zebra/Base.lproj/Localizable.strings
+++ b/Zebra/Base.lproj/Localizable.strings
@@ -139,6 +139,7 @@
 "Sign Out" = "Sign Out";
 "Your Purchases" = "Your Purchases";
 "No Storefronts Available" = "No Storefronts Available";
+"Could not authenticate" = "Could not authenticate";
 "Could not complete purchase" = "Could not complete purchase";
 "Could not complete purchase, no payment secret was found" = "Could not complete purchase, no payment secret was found";
 "No packages purchased" = "No packages purchased";
@@ -185,9 +186,15 @@
 
 "Could not parse %@ from %@" = "Could not parse %@ from %@";
 "Could not find a download URL for" = "Could not find a download URL for";
+"Authorizing Download for %@" = "Authorizing Download for %@";
+"Couldn't authorize download for %@." = "Couldn't authorize download for %@.";
+"Reason: %@." = "Reason: %@.";
+"The Payment API is not supported on less than iOS 11.0" = "The Payment API is not supported on less than iOS 11.0";
 "Could not download Release file from %@. Reason: %@" = "Could not download Release file from %@. Reason: %@";
 "Could not download Packages file from %@. Reason: %@" = "Could not download Packages file from %@. Reason: %@";
 "Could not download one or more files from %@. Reason: %@" = "Could not download one or more files from %@. Reason: %@";
+
+"Error while moving file at %@ to %@" = "Error while moving file at %@ to %@";
 
 "The URL you entered is not valid. Please check it and try again." = "The URL you entered is not valid. Please check it and try again.";
 
@@ -302,6 +309,7 @@
 "Console" = "Console";
 "Performing Actions..." = "Performing Actions...";
 "Updating icon cache asynchronously..." = "Updating icon cache asynchronously...";
+"uicache is not available on the simulator" = "uicache is not available on the simulator";
 "This may take awhile and Zebra may crash. It is okay if it does." = "This may take awhile and Zebra may crash. It is okay if it does.";
 "Close Zebra" = "Close Zebra";
 "Closing Zebra..." = "Closing Zebra...";

--- a/Zebra/Console/ZBConsoleViewController.m
+++ b/Zebra/Console/ZBConsoleViewController.m
@@ -500,7 +500,7 @@
     if (![ZBDevice needsSimulation]) {
         [ZBDevice uicache:arguments observer:self];
     } else {
-        [self writeToConsole:@"uicache is not available on the simulator" atLevel:ZBLogLevelWarning];
+        [self writeToConsole:NSLocalizedString(@"uicache is not available on the simulator", @"") atLevel:ZBLogLevelWarning];
     }
 }
 

--- a/Zebra/Downloads/ZBDownloadManager.m
+++ b/Zebra/Downloads/ZBDownloadManager.m
@@ -157,7 +157,7 @@
             [packageTasksMap setObject:package forKey:@(downloadTask.taskIdentifier)];
             [downloadDelegate startedPackageDownload:package];
         } else if (package.requiresAuthorization) {
-            [self postStatusUpdate:[NSString stringWithFormat:@"Authorizing Download for %@", package.name] atLevel:ZBLogLevelDescript];
+            [self postStatusUpdate:[NSString stringWithFormat:NSLocalizedString(@"Authorizing Download for %@", @""), package.name] atLevel:ZBLogLevelDescript];
             if (@available(iOS 11.0, *)) {
                 [self authorizeDownloadForPackage:package completion:^(NSURL *downloadURL, NSError *error) {
                     if (downloadURL && !error) {
@@ -168,12 +168,12 @@
                         [self->downloadDelegate startedPackageDownload:package];
                     }
                     else if (error) {
-                        [self postStatusUpdate:[NSString stringWithFormat:@"Couldn't authorize download for %@.", package.name] atLevel:ZBLogLevelError];
-                        [self postStatusUpdate:[NSString stringWithFormat:@"Reason: %@.", error.localizedDescription] atLevel:ZBLogLevelError];
+                        [self postStatusUpdate:[NSString stringWithFormat:NSLocalizedString(@"Couldn't authorize download for %@.", @""), package.name] atLevel:ZBLogLevelError];
+                        [self postStatusUpdate:[NSString stringWithFormat:NSLocalizedString(@"Reason: %@.", @""), error.localizedDescription] atLevel:ZBLogLevelError];
                     }
                 }];
             } else {
-                [self postStatusUpdate:@"The Payment API is not supported on less than iOS 11.0" atLevel:ZBLogLevelError];
+                [self postStatusUpdate:NSLocalizedString(@"The Payment API is not supported on less than iOS 11.0", @"") atLevel:ZBLogLevelError];
             }
         } else {
             NSString *baseString = [base absoluteString];
@@ -595,7 +595,8 @@
                     ZBPackage *package = self->packageTasksMap[@(downloadTask.taskIdentifier)];
                     if (error) {
                         [self cancelAllTasksForSession:self->session];
-                        [self->downloadDelegate postStatusUpdate:[NSString stringWithFormat:@"[Zebra] Error while moving file at %@ to %@: %@\n", location, finalPath, error.localizedDescription] atLevel:ZBLogLevelError];
+                        NSString *text = [NSString stringWithFormat:[NSString stringWithFormat:@"[Zebra] %@: %%@\n", NSLocalizedString(@"Error while moving file at %@ to %@", @"")], location, finalPath, error.localizedDescription];
+                        [self->downloadDelegate postStatusUpdate:text atLevel:ZBLogLevelError];
                         
                         [self->downloadDelegate finishedPackageDownload:package withError:error];
                     } else {

--- a/Zebra/Tabs/Home/Stores/ZBStoresListTableViewController.m
+++ b/Zebra/Tabs/Home/Stores/ZBStoresListTableViewController.m
@@ -100,10 +100,10 @@
         [source authenticate:^(BOOL success, NSError * _Nullable error) {
             if (!success || error) {
                 if (error) {
-                    [ZBAppDelegate sendAlertFrom:self message:[NSString stringWithFormat:@"Could not authenticate: %@", error.localizedDescription]];
+                    [ZBAppDelegate sendAlertFrom:self message:[NSString stringWithFormat:@"%@: %@", NSLocalizedString(@"Could not authenticate", @""), error.localizedDescription]];
                 }
                 else {
-                    [ZBAppDelegate sendAlertFrom:self message:@"Could not authenticate"];
+                    [ZBAppDelegate sendAlertFrom:self message:NSLocalizedString(@"Could not authenticate", @"")];
                 }
             }
             else {

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceSectionsListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceSectionsListTableViewController.m
@@ -171,10 +171,10 @@
         [source authenticate:^(BOOL success, NSError * _Nullable error) {
             if (!success || error) {
                 if (error) {
-                    if (error.code != 1) [ZBAppDelegate sendAlertFrom:self message:[NSString stringWithFormat:@"Could not authenticate: %@", error.localizedDescription]];
+                    if (error.code != 1) [ZBAppDelegate sendAlertFrom:self message:[NSString stringWithFormat:NSLocalizedString(@"Could not authenticate: %@", @""), error.localizedDescription]];
                 }
                 else {
-                    [ZBAppDelegate sendAlertFrom:self message:@"Could not authenticate"];
+                    [ZBAppDelegate sendAlertFrom:self message:NSLocalizedString(@"Could not authenticate", @"")];
                 }
             }
             else {


### PR DESCRIPTION
**Added:**

- uicache is not available on the simulator
- Authorizing Download for %@
- Couldn't authorize download for %@.
- Reason: %@.
- The Payment API is not supported on less than iOS 11.0
- Error while moving file at %@ to %@
- Could not authenticate
- Logged in as %@

**Removed:**

- Could not complete purchase, no payment secret was found

**Hidden:**

- Hide UUID