### PR TITLE
apt --allow-remove-essential

### DIFF
--- a/Zebra/Queue/ZBQueue.m
+++ b/Zebra/Queue/ZBQueue.m
@@ -242,7 +242,7 @@
 
     if ([self queueHasPackages:ZBQueueTypeRemove]) {
         if ([self containsEssentialOrRequiredPackage]) {
-            NSMutableArray *removeCommand = [@[@"apt", @"--allow-remove-essential", @"remove",@"-oApt::Get::HideAutoRemove=true", @"-oquiet::NoProgress=true", @"-oquiet::NoStatistic=true"] mutableCopy];
+            NSMutableArray *removeCommand = [@[@"apt", @"-yqf", @"--allow-remove-essential", @"remove",@"-oApt::Get::HideAutoRemove=true", @"-oquiet::NoProgress=true", @"-oquiet::NoStatistic=true"] mutableCopy];
             
             if (ignoreDependencies) {
                 [removeCommand addObject:@"--force-depends"];

--- a/Zebra/Queue/ZBQueue.m
+++ b/Zebra/Queue/ZBQueue.m
@@ -241,8 +241,8 @@
     NSString *binary = baseCommand[0];
 
     if ([self queueHasPackages:ZBQueueTypeRemove]) {
-        if ([self containsEssentialOrRequiredPackage]) { //We need to use dpkg to remove these packages, I haven't found a flag that will enable APT to do this
-            NSMutableArray *removeCommand = [@[@"dpkg", @"-r", @"--force-remove-essential"] mutableCopy];
+        if ([self containsEssentialOrRequiredPackage]) {
+            NSMutableArray *removeCommand = [@[@"apt", @"--allow-remove-essential", @"remove",@"-oApt::Get::HideAutoRemove=true", @"-oquiet::NoProgress=true", @"-oquiet::NoStatistic=true"] mutableCopy];
             
             if (ignoreDependencies) {
                 [removeCommand addObject:@"--force-depends"];


### PR DESCRIPTION
Found APT flag/option to allow removal of essential packages.

Hopefully I added this correctly. Goes with #1084 

![7985B383-2DDA-4DD9-B933-9C8AC1578174](https://user-images.githubusercontent.com/5729320/79211077-568c5980-7e0b-11ea-82ce-71269c2f660d.jpeg)
