### PR TITLE
Add Provides: cydia to the control file

### DIFF
--- a/control
+++ b/control
@@ -3,6 +3,7 @@ Name: Zebra
 Version: 1.1~beta5-1
 Architecture: iphoneos-arm
 Depends: dpkg, uikittools, firmware (>= 9.0)
+Provides:cydia
 Description: A Useful Package Manager
 Maintainer: Wilson Styres <wilson@styres.me>
 Author: Wilson Styres <wilson@styres.me>

--- a/control
+++ b/control
@@ -3,7 +3,7 @@ Name: Zebra
 Version: 1.1~beta5-1
 Architecture: iphoneos-arm
 Depends: dpkg, uikittools, firmware (>= 9.0)
-Provides:cydia
+Provides: cydia
 Description: A Useful Package Manager
 Maintainer: Wilson Styres <wilson@styres.me>
 Author: Wilson Styres <wilson@styres.me>


### PR DESCRIPTION
Will help negate the Essential from apt.bingner.com package always requiring an update when Cydia is not installed.


This will not affect Cydia in any way. But will only create a virtual package of Cydia in Cydia's absence. 

[Virtual packages - Provides](https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides)