### PR TITLE
[Packages] Select version to install option

### DIFF
--- a/Zebra.xcodeproj/project.pbxproj
+++ b/Zebra.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		9ED47D942365886300CF2021 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A53E54A3245B08740082BF69 /* ZBUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZBUtils.h; sourceTree = "<group>"; };
 		A53E54A4245B08740082BF69 /* ZBUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZBUtils.m; sourceTree = "<group>"; };
+		A57BC3EA245D13F200D1687D /* UIAlertController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIAlertController+Private.h"; sourceTree = "<group>"; };
 		A59E32832434E7DE00077D6E /* AccessibilityUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityUtilities.h; sourceTree = "<group>"; };
 		BFC6DB1C236D9B9000DA5534 /* ZBSettingsSelectionTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZBSettingsSelectionTableViewController.h; sourceTree = "<group>"; };
 		BFC6DB1D236D9BD500DA5534 /* ZBSettingsSelectionTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZBSettingsSelectionTableViewController.m; sourceTree = "<group>"; };
@@ -728,6 +729,7 @@
 				89B20FD121B7635300F7EEFE /* NSTask.h */,
 				895071972239E2FD004AE338 /* MobileGestalt.h */,
 				A59E32832434E7DE00077D6E /* AccessibilityUtilities.h */,
+				A57BC3EA245D13F200D1687D /* UIAlertController+Private.h */,
 			);
 			path = Headers;
 			sourceTree = "<group>";

--- a/Zebra/Headers/UIAlertController+Private.h
+++ b/Zebra/Headers/UIAlertController+Private.h
@@ -1,0 +1,16 @@
+//
+//  UIAlertController+Private.h
+//  Zebra
+//
+//  Created by Thatchapon Unprasert on 2/5/2563 BE.
+//  Copyright © 2563 Wilson Styres. All rights reserved.
+//
+
+#ifndef UIAlertController_Private_h
+#define UIAlertController_Private_h
+
+@interface UIAlertController (Private)
+@property (setter=_setIndexesOfActionSectionSeparators:, getter=_indexesOfActionSectionSeparators, nonatomic, copy) NSIndexSet * indexesOfActionSectionSeparators API_AVAILABLE(ios(10.0));
+@end
+
+#endif /* UIAlertController_Private_h */

--- a/Zebra/Tabs/Packages/Helpers/ZBPackage.h
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackage.h
@@ -60,7 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString * _Nullable)getField:(NSString *)field;
 - (BOOL)isInstalled:(BOOL)strict;
 - (BOOL)isReinstallable;
-- (NSArray <ZBPackage *> *)otherVersions;
+- (NSMutableArray <ZBPackage *> *)allVersions;
+- (NSMutableArray <ZBPackage *> *)otherVersions;
 - (NSArray <ZBPackage *> *)lesserVersions;
 - (NSArray <ZBPackage *> *)greaterVersions;
 - (BOOL)ignoreUpdates;

--- a/Zebra/Tabs/Packages/Helpers/ZBPackage.h
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackage.h
@@ -62,8 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isReinstallable;
 - (NSMutableArray <ZBPackage *> *)allVersions;
 - (NSMutableArray <ZBPackage *> *)otherVersions;
-- (NSArray <ZBPackage *> *)lesserVersions;
-- (NSArray <ZBPackage *> *)greaterVersions;
+- (NSMutableArray <ZBPackage *> *)lesserVersions;
+- (NSMutableArray <ZBPackage *> *)greaterVersions;
 - (BOOL)ignoreUpdates;
 - (void)setIgnoreUpdates:(BOOL)ignore;
 - (NSString *)downloadSizeString;

--- a/Zebra/Tabs/Packages/Helpers/ZBPackage.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackage.m
@@ -631,7 +631,7 @@
     return versions;
 }
 
-- (NSArray <ZBPackage *> *)lesserVersions {
+- (NSMutableArray <ZBPackage *> *)lesserVersions {
     NSMutableArray *versions = [[self otherVersions] mutableCopy];
     NSMutableArray *lesserVersions = [versions mutableCopy];
     for (ZBPackage *package in versions) {
@@ -643,7 +643,7 @@
     return lesserVersions;
 }
 
-- (NSArray <ZBPackage *> *)greaterVersions {
+- (NSMutableArray <ZBPackage *> *)greaterVersions {
     NSMutableArray *versions = [[self otherVersions] mutableCopy];
     NSMutableArray *greaterVersions = [versions mutableCopy];
     for (ZBPackage *package in versions) {
@@ -801,7 +801,7 @@
             }
         }
         if ([[self allVersions] count] > 1) { // Show "Select version" instead of "Install" as it makes more senses
-            [actions addObject:@(ZBPackageActionChooseOneToInstall)];
+            [actions addObject:@(ZBPackageActionSelectVersion)];
         }
         else {
             [actions addObject:@(ZBPackageActionInstall)]; // Show "Install" otherwise (could be disabled if its already in the Queue)

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActionType.h
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActionType.h
@@ -17,7 +17,7 @@ typedef enum : NSUInteger {
     ZBPackageActionUpgrade,
     ZBPackageActionShowUpdates,
     ZBPackageActionHideUpdates,
-    ZBPackageActionChooseOneToInstall,
+    ZBPackageActionSelectVersion,
 } ZBPackageActionType;
 
 #endif /* ZBPackageActionType_h */

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActionType.h
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActionType.h
@@ -17,6 +17,7 @@ typedef enum : NSUInteger {
     ZBPackageActionUpgrade,
     ZBPackageActionShowUpdates,
     ZBPackageActionHideUpdates,
+    ZBPackageActionChooseOneToInstall,
 } ZBPackageActionType;
 
 #endif /* ZBPackageActionType_h */

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
@@ -126,7 +126,7 @@
 }
 
 + (NSString *)determinePackageTitle:(ZBPackage *)package versionStrings:(NSCountedSet *)versionStrings withLatest:(BOOL)latest {
-    NSString *versionString = latest ? NSLocalizedString(@"Latest", @"") : [package version];
+    NSString *versionString = latest ? [NSString stringWithFormat:@"%@ (%@)", NSLocalizedString(@"Latest", @""), [package version]] : [package version];
     return [versionStrings countForObject:[package version]] > 1 ? [NSString stringWithFormat:@"%@ (%@)", versionString, [[package source] label]] : versionString;
 }
 


### PR DESCRIPTION
Addresses #975 

This PR makes "Install" action for packages that have multiple versions and are not installed shows the version selector. This also brings design change in package action characters, as seen from the screenshots below:

![Installed](https://user-images.githubusercontent.com/3608783/80780281-a3588a00-8b98-11ea-8a0d-2796c487255a.png)
![Not Installed](https://user-images.githubusercontent.com/3608783/80780371-eca8d980-8b98-11ea-8fa5-071eb0e5289a.png)

"Downgrade" now uses "↓", leading to having "Install" uses "⤓".

This will also need a new translation for "Select version to install", as seen from the action sheet:

![Select version](https://user-images.githubusercontent.com/3608783/80853266-9780cc80-8c59-11ea-9bf2-ae6be21b14cd.png)

Notice also the separator between the latest version and the other versions. The private API responsible for this is available in iOS 10 onwards.
