### PR TITLE
[Source] Improve adding sources

### DIFF
--- a/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
@@ -144,12 +144,7 @@
     error:nil];
     NSTextCheckingResult *match = [regex firstMatchInString:textView.text options:0 range:NSMakeRange(0, textView.text.length)];
     
-    if (match) {
-        [self.addButton setEnabled:YES];
-    }
-    else {
-        [self.addButton setEnabled:NO];
-    }
+    [self.addButton setEnabled:match];
 }
 
 @end

--- a/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
@@ -139,7 +139,17 @@
 }
 
 - (void)textViewDidChange:(UITextView *)textView {
-    self.addButton.enabled = self.addSourceTextView.text.length != 0;
+    // check if it is URL or not
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"http(s)?://((\\w)|([0-9])|([-|_]))+(\\.|/)+((\\w)|([0-9])|([-|_]))+" options:NSRegularExpressionCaseInsensitive
+    error:nil];
+    NSTextCheckingResult *match = [regex firstMatchInString:textView.text options:0 range:NSMakeRange(0, textView.text.length)];
+    
+    if (match) {
+        [self.addButton setEnabled:YES];
+    }
+    else {
+        [self.addButton setEnabled:NO];
+    }
 }
 
 @end

--- a/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBAddSourceViewController.m
@@ -58,7 +58,7 @@
     
     if (self.text && [self.text hasPrefix:@"http"]) {
         self.addSourceTextView.text = self.text;
-        self.addButton.enabled = self.addSourceTextView.text.length;
+        [self textViewDidChange:self.addSourceTextView];
     }
 }
 

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
@@ -420,7 +420,6 @@
         [self checkSourceURL:sourceURL];
     }];
     
-    [add setEnabled:false];
     [alertController addAction:add];
     
     [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Add Multiple", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -432,8 +431,10 @@
     [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
         if (placeholder != NULL) {
             textField.text = placeholder;
+            [add setEnabled:YES];
         } else {
             textField.text = @"https://";
+            [add setEnabled:NO];
         }
         textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
         textField.autocorrectionType = UITextAutocorrectionTypeNo;
@@ -458,8 +459,7 @@
     if (match) {
         if ([textField.text hasPrefix:@"https"]) {
             textField.text = [textField.text substringFromIndex:8];
-        }
-        else {
+        } else {
             textField.text = [textField.text substringFromIndex:7];
         }
     }
@@ -470,8 +470,7 @@
     NSTextCheckingResult *isURL = [regex firstMatchInString:textField.text options:0 range:NSMakeRange(0, textField.text.length)];
     if (isURL) {
         [add setEnabled:YES];
-    }
-    else {
+    } else {
         [add setEnabled:NO];
     }
 }
@@ -652,7 +651,14 @@
     if (![path isEqualToString:@""]) {
         NSArray *components = [path pathComponents];
         if ([components count] == 2) {
-            [self showAddSourceAlert:NULL];
+            UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+            NSURL *url = [NSURL URLWithString:pasteboard.string];
+            BOOL isValidURL = url && [NSURLConnection canHandleRequest:[NSURLRequest requestWithURL:url]];
+            if (!isValidURL) {
+                [self showAddSourceAlert:NULL];
+            } else {
+                [self showAddSourceAlert:[url absoluteString]];
+            }
         } else if ([components count] >= 4) {
             NSString *urlString = [path componentsSeparatedByString:@"/add/"][1];
             

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
@@ -468,11 +468,8 @@
     regex = [NSRegularExpression regularExpressionWithPattern:@"(http(s)?://){1}((\\w)|([0-9])|([-|_]))+(\\.|/)+((\\w)|([0-9])|([-|_]))+" options:NSRegularExpressionCaseInsensitive
     error:nil];
     NSTextCheckingResult *isURL = [regex firstMatchInString:textField.text options:0 range:NSMakeRange(0, textField.text.length)];
-    if (isURL) {
-        [add setEnabled:YES];
-    } else {
-        [add setEnabled:NO];
-    }
+    
+    [add setEnabled:isURL];
 }
 
 - (void)checkSourceURL:(NSURL *)sourceURL {

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
@@ -451,12 +451,24 @@
     UITextField *textField = alertController.textFields.firstObject;
     UIAlertAction * add = alertController.actions[1];
     
-    // check if it is URL or not
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"http(s)?://((\\w)|([0-9])|([-|_]))+(\\.|/)+((\\w)|([0-9])|([-|_]))+" options:NSRegularExpressionCaseInsensitive
+    // This will be useful when pasting the url in text field
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(http(s)?://){2}" options:NSRegularExpressionCaseInsensitive
     error:nil];
     NSTextCheckingResult *match = [regex firstMatchInString:textField.text options:0 range:NSMakeRange(0, textField.text.length)];
-    
     if (match) {
+        if ([textField.text hasPrefix:@"https"]) {
+            textField.text = [textField.text substringFromIndex:8];
+        }
+        else {
+            textField.text = [textField.text substringFromIndex:7];
+        }
+    }
+    
+    // check if it is URL or not
+    regex = [NSRegularExpression regularExpressionWithPattern:@"(http(s)?://){1}((\\w)|([0-9])|([-|_]))+(\\.|/)+((\\w)|([0-9])|([-|_]))+" options:NSRegularExpressionCaseInsensitive
+    error:nil];
+    NSTextCheckingResult *isURL = [regex firstMatchInString:textField.text options:0 range:NSMakeRange(0, textField.text.length)];
+    if (isURL) {
         [add setEnabled:YES];
     }
     else {


### PR DESCRIPTION
Changes:
 - Disable add button when the text does not fill with valid URL
 - Remove "https://" or "http://" when doubled. (Useful when pasting the URL to the text without deleting the auto filled "https://" manually. Fix https://github.com/wstyres/Zebra/issues/1188#issuecomment-636118934
 - Auto fill the valid URL from clipboard when opening Zebra using scheme (zbra://sources). Fix https://github.com/wstyres/Zebra/issues/1188#issuecomment-625675843

Fixes #1188 