### PR TITLE
[Notifications] Support for push notifications on package updates

### DIFF
--- a/Zebra.xcodeproj/project.pbxproj
+++ b/Zebra.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		89F205482463A75000896021 /* GoogleAppMeasurement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89F2053B2463A74F00896021 /* GoogleAppMeasurement.framework */; };
 		89F213C023BED9D300F3E5E5 /* ZBBaseSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F213BF23BED9D300F3E5E5 /* ZBBaseSource.m */; };
 		89F8730323653D280070160A /* UIVisualEffectView+Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F8730223653D280070160A /* UIVisualEffectView+Theme.m */; };
+		8EA226B0248BC4E100596838 /* ZBNotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA226AF248BC4E100596838 /* ZBNotificationManager.m */; };
 		9E06A9EF22D0842400DBBC38 /* ZBSourceTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9E06A9EE22D0842400DBBC38 /* ZBSourceTableViewCell.xib */; };
 		9E0D952F2358AFF500C6C2B2 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0D952C2358AFEF00C6C2B2 /* SDWebImage.framework */; };
 		9E0D95302358AFF500C6C2B2 /* SDWebImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0D952C2358AFEF00C6C2B2 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -550,6 +551,8 @@
 		89F8730023653CC90070160A /* UIVisualEffectView+Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIVisualEffectView+Theme.h"; sourceTree = "<group>"; };
 		89F8730223653D280070160A /* UIVisualEffectView+Theme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIVisualEffectView+Theme.m"; sourceTree = "<group>"; };
 		89FEA4132264BF68002647A2 /* ZBLogLevel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZBLogLevel.h; sourceTree = "<group>"; };
+		8EA226AF248BC4E100596838 /* ZBNotificationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZBNotificationManager.m; sourceTree = "<group>"; };
+		8EA226B1248BC50400596838 /* ZBNotificationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZBNotificationManager.h; sourceTree = "<group>"; };
 		95B7FFF323643B74003616EC /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		96F1BEE92363DAB3009B0D27 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		9E06A9EE22D0842400DBBC38 /* ZBSourceTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZBSourceTableViewCell.xib; sourceTree = "<group>"; };
@@ -1070,6 +1073,7 @@
 				8958F28E23C3C56800FB64D9 /* Headers */,
 				36A1D8F8230A15FC002694BE /* JSONParsing */,
 				363FE2432287858200B69929 /* Keychain */,
+				8EA226AE248BC4B000596838 /* Notifications */,
 				8991FF9A21B21069004FCE23 /* Parsel */,
 				89DD2683220156F800CD31A0 /* Queue */,
 				89E8633E21D5A9CE0081E485 /* Resources */,
@@ -1256,6 +1260,15 @@
 				49009A632471D442005CA2E2 /* ZBScreenshotCollectionViewCell.xib */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		8EA226AE248BC4B000596838 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				8EA226B1248BC50400596838 /* ZBNotificationManager.h */,
+				8EA226AF248BC4E100596838 /* ZBNotificationManager.m */,
+			);
+			path = Notifications;
 			sourceTree = "<group>";
 		};
 		9E0D95232358AFEE00C6C2B2 /* Products */ = {
@@ -1611,6 +1624,7 @@
 				89CA2139224043D1008F09DB /* vercmp.c in Sources */,
 				89A1B735223C97210053D0E2 /* ZBTabBarController.m in Sources */,
 				9EAE364B2289224E004CBBA3 /* ZBPackageActions.m in Sources */,
+				8EA226B0248BC4E100596838 /* ZBNotificationManager.m in Sources */,
 				4910B3A82426BD5C00306C5C /* ZBSourcesAccountBanner.m in Sources */,
 				8916AC2323CAAECC008BA02C /* ZBChangelogTableViewController.m in Sources */,
 				369CF11322DA2361007EA0F7 /* ZBInstalledFilesTableViewController.m in Sources */,

--- a/Zebra/Base.lproj/Localizable.strings
+++ b/Zebra/Base.lproj/Localizable.strings
@@ -494,3 +494,5 @@
 
 "Update available for %@" = "Update available for %@";
 "Version %@ is available on %@." = "Version %@ is available on %@.";
+"%d updates available" = "%d updates available";
+"%@ and %d more can be updated." = "%@ and %d more can be updated.";

--- a/Zebra/Base.lproj/Localizable.strings
+++ b/Zebra/Base.lproj/Localizable.strings
@@ -489,3 +489,8 @@
 
 "Package Not Available" = "Package Not Available";
 "The package you request is no longer available. It might have been removed from your sources or the package ID requested was incorrect." = "The package you request is no longer available. It might have been removed from your sources or the package ID requested was incorrect.";
+
+// Notifications
+
+"Update available for %@" = "Update available for %@";
+"Version %@ is available on %@." = "Version %@ is available on %@.";

--- a/Zebra/Info.plist
+++ b/Zebra/Info.plist
@@ -326,6 +326,10 @@
 			<string>Add</string>
 		</dict>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Zebra/Notifications/ZBNotificationManager.h
+++ b/Zebra/Notifications/ZBNotificationManager.h
@@ -1,0 +1,33 @@
+//
+//  ZBNotificationManager.h
+//  Zebra
+//
+//  Created by Arthur Chaloin on 06/06/2020.
+//  Copyright © 2020 Wilson Styres. All rights reserved.
+//
+
+#ifndef ZBNotificationManager_h
+#define ZBNotificationManager_h
+
+#import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
+#import <ZBDatabaseDelegate.h>
+#import <ZBPackage.h>
+
+typedef void (^BackgroundCompletionHandler)(UIBackgroundFetchResult);
+
+typedef NSMutableArray<ZBPackage *> ZBPackageList;
+
+@interface ZBNotificationManager : NSObject <ZBDatabaseDelegate, UNUserNotificationCenterDelegate>
+
+- (void)ensureNotificationAccess;
+- (void)performBackgroundFetch:(nonnull BackgroundCompletionHandler)completionHandler;
+- (UIBackgroundFetchResult)notifyNewUpdatesBetween:(nonnull ZBPackageList *)oldUpdates newUpdates:(nonnull ZBPackageList *)newUpdates;
+- (void)notifyUpdateForPackage:(nonnull ZBPackage *)package;
+- (void)notify:(nonnull NSString *)body withTitle:(nonnull NSString *)title withUserInfo:(nonnull NSDictionary *)userInfo;
+
++ (nonnull instancetype)sharedInstance;
+
+@end
+
+#endif /* ZBNotificationManager_h */

--- a/Zebra/Notifications/ZBNotificationManager.h
+++ b/Zebra/Notifications/ZBNotificationManager.h
@@ -23,7 +23,7 @@ typedef NSMutableArray<ZBPackage *> ZBPackageList;
 - (void)ensureNotificationAccess;
 - (void)performBackgroundFetch:(nonnull BackgroundCompletionHandler)completionHandler;
 - (UIBackgroundFetchResult)notifyNewUpdatesBetween:(nonnull ZBPackageList *)oldUpdates newUpdates:(nonnull ZBPackageList *)newUpdates;
-- (void)notifyUpdateForPackage:(nonnull ZBPackage *)package;
+- (void)notifyUpdateForPackages:(nonnull ZBPackageList *)packages;
 - (void)notify:(nonnull NSString *)body withTitle:(nonnull NSString *)title withUserInfo:(nonnull NSDictionary *)userInfo;
 
 + (nonnull instancetype)sharedInstance;

--- a/Zebra/Notifications/ZBNotificationManager.m
+++ b/Zebra/Notifications/ZBNotificationManager.m
@@ -79,11 +79,9 @@
     NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Update available for %@", @""), package.name];
     NSString *text = [NSString stringWithFormat:NSLocalizedString(@"Version %@ is available on %@.", @""), package.version, [package.source label]];
 
-    id userInfoData[] = { [NSString stringWithFormat:@"zbra://packages/%@", package.identifier ] };
-    id userInfoKeys[] = { @"openURL" };
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjects:userInfoData forKeys:userInfoKeys count:1];
-
-    [self notify:text withTitle:title withUserInfo:userInfo];
+    [self notify:text withTitle:title withUserInfo:@{
+        @"openURL": [NSString stringWithFormat:@"zbra://packages/%@", package.identifier],
+    }];
 }
 
 - (void)notify:(NSString *)body withTitle:(NSString *)title withUserInfo:(NSDictionary *)userInfo {

--- a/Zebra/Notifications/ZBNotificationManager.m
+++ b/Zebra/Notifications/ZBNotificationManager.m
@@ -98,7 +98,7 @@
     content.userInfo = userInfo;
 
     UNNotificationRequest* request = [UNNotificationRequest
-           requestWithIdentifier:@"MorningAlarm" content:content trigger:trigger];
+           requestWithIdentifier:@"xyz.willy.Zebra.updates" content:content trigger:trigger];
 
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {

--- a/Zebra/Notifications/ZBNotificationManager.m
+++ b/Zebra/Notifications/ZBNotificationManager.m
@@ -43,7 +43,7 @@
     self.completionHandler = completionHandler;
     self.oldUpdates = [databaseManager packagesWithUpdates];
 
-    [databaseManager updateDatabaseUsingCaching:NO userRequested:YES];
+    [databaseManager updateDatabaseUsingCaching:YES userRequested:YES];
 }
 
 - (UIBackgroundFetchResult)notifyNewUpdatesBetween:(ZBPackageList *)oldUpdates

--- a/Zebra/Notifications/ZBNotificationManager.m
+++ b/Zebra/Notifications/ZBNotificationManager.m
@@ -1,0 +1,171 @@
+//
+//  ZBNotificationManager.m
+//  Zebra
+//
+//  Created by Arthur Chaloin on 06/06/2020.
+//  Copyright © 2020 Wilson Styres. All rights reserved.
+//
+
+#import "ZBNotificationManager.h"
+#import <ZBDatabaseManager.h>
+#import <ZBSource.h>
+
+@interface ZBNotificationManager ()
+
+@property () BackgroundCompletionHandler completionHandler;
+@property () ZBPackageList *oldUpdates;
+
+- (void)fetchCompleted:(UIBackgroundFetchResult)result;
+
+@end
+
+@implementation ZBNotificationManager
+
+- (void)ensureNotificationAccess {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"[Zebra] Error: %@", error.localizedDescription);
+        } else if (!granted) {
+            NSLog(@"[Zebra] Authorization was not granted.");
+        } else {
+            NSLog(@"[Zebra] Notification access granted.");
+        }
+    }];
+    
+    center.delegate = self;
+}
+
+- (void)performBackgroundFetch:(BackgroundCompletionHandler)completionHandler {
+    ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
+    
+    self.completionHandler = completionHandler;
+    self.oldUpdates = [databaseManager packagesWithUpdates];
+
+    [databaseManager updateDatabaseUsingCaching:NO userRequested:YES];
+}
+
+- (UIBackgroundFetchResult)notifyNewUpdatesBetween:(ZBPackageList *)oldUpdates
+                                        newUpdates:(ZBPackageList *)newUpdates {
+    UIBackgroundFetchResult result = UIBackgroundFetchResultNoData;
+    
+    for (ZBPackage *package in newUpdates) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", package.identifier];
+        NSArray<ZBPackage *> *filteredPackages = [oldUpdates filteredArrayUsingPredicate:predicate];
+        
+        if (filteredPackages.count > 1) {
+            NSLog(@"WARNING: Received multiple updates for the same package. This is most probably a developer error.");
+            continue;
+        }
+        else if (filteredPackages.count <= 0) {
+            [self notifyUpdateForPackage:package];
+            result = UIBackgroundFetchResultNewData;
+        }
+        else {
+            ZBPackage *oldPackage = filteredPackages[0];
+            
+            if (![package.version isEqualToString:oldPackage.version]) {
+                [self notifyUpdateForPackage:package];
+                result = UIBackgroundFetchResultNewData;
+            }
+        }
+    }
+
+    return result;
+}
+
+- (void)notifyUpdateForPackage:(ZBPackage *)package {
+    NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Update available for %@", @""), package.name];
+    NSString *text = [NSString stringWithFormat:NSLocalizedString(@"Version %@ is available on %@.", @""), package.version, [package.source label]];
+
+    id userInfoData[] = { [NSString stringWithFormat:@"zbra://packages/%@", package.identifier ] };
+    id userInfoKeys[] = { @"openURL" };
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjects:userInfoData forKeys:userInfoKeys count:1];
+
+    [self notify:text withTitle:title withUserInfo:userInfo];
+}
+
+- (void)notify:(NSString *)body withTitle:(NSString *)title withUserInfo:(NSDictionary *)userInfo {
+    NSDate* now = [NSDate date];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSDateComponents *date = [calendar components:NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour|NSCalendarUnitMinute|NSCalendarUnitSecond|NSCalendarUnitTimeZone fromDate:[now dateByAddingTimeInterval:3]];
+
+    UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger
+           triggerWithDateMatchingComponents:date repeats:NO];
+
+    UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
+    content.title = title;
+    content.body = body;
+    content.userInfo = userInfo;
+
+    UNNotificationRequest* request = [UNNotificationRequest
+           requestWithIdentifier:@"MorningAlarm" content:content trigger:trigger];
+
+    UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+    [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
+       if (error != nil) {
+           NSLog(@"%@", error.localizedDescription);
+       }
+    }];
+}
+
+- (void)fetchCompleted:(UIBackgroundFetchResult)result {
+    self.oldUpdates = nil;
+
+    if (self.completionHandler != nil) {
+        BackgroundCompletionHandler completionHandler = self.completionHandler;
+        self.completionHandler = nil;
+        completionHandler(result);
+    }
+}
+
+#pragma mark ZBDatabaseDelegate
+
+- (void)databaseCompletedUpdate:(int)numberOfUpdates {
+    if (numberOfUpdates <= 0) {
+        [self fetchCompleted:UIBackgroundFetchResultNoData];
+        return;
+    }
+
+    ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
+    ZBPackageList *newUpdates = [databaseManager packagesWithUpdates];
+
+    UIBackgroundFetchResult result = [self notifyNewUpdatesBetween:self.oldUpdates newUpdates:newUpdates];
+    [self fetchCompleted:result];
+}
+
+- (void)databaseStartedUpdate {}
+
+#pragma mark UNUserNotificationCenterDelegate
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response withCompletionHandler:(nonnull void (^)(void))completionHandler {
+    
+    NSDictionary *userInfo = response.notification.request.content.userInfo;
+    NSURL *openURL = [NSURL URLWithString:[userInfo objectForKey:@"openURL"]];
+    
+    if (!openURL) {
+        completionHandler();
+        return;
+    }
+
+    [UIApplication.sharedApplication openURL:openURL
+                                     options:[NSMutableDictionary dictionary]
+                           completionHandler:^(BOOL _) {
+        completionHandler();
+    }];
+}
+
+#pragma mark Static methods
+
++ (id)sharedInstance {
+   static ZBNotificationManager *instance = nil;
+   if (instance == nil) {
+       instance = [ZBNotificationManager new];
+       ZBDatabaseManager *databaseManager = [ZBDatabaseManager sharedInstance];
+       [databaseManager addDatabaseDelegate:instance];
+   }
+   return instance;
+}
+
+@end

--- a/Zebra/fr.lproj/Localizable.strings
+++ b/Zebra/fr.lproj/Localizable.strings
@@ -486,3 +486,8 @@
 
 "Package Not Available" = "Paquet non disponible";
 "The package you request is no longer available. It might have been removed from your sources or the package ID requested was incorrect." = "Le paquet que vous demandez n'est plus disponible. Il est possible qu'il ait été supprimé de vos sources ou que l'identifiant du paquet demandé soit incorrect.";
+
+// Notifications
+
+"Update available for %@" = "Mise à jour disponible pour %@";
+"Version %@ is available on %@." = "La version %@ est disponible sur %@.";

--- a/Zebra/fr.lproj/Localizable.strings
+++ b/Zebra/fr.lproj/Localizable.strings
@@ -491,3 +491,5 @@
 
 "Update available for %@" = "Mise à jour disponible pour %@";
 "Version %@ is available on %@." = "La version %@ est disponible sur %@.";
+"%d updates available" = "%d mises à jour disponibles";
+"%@ and %d more can be updated." = "%@ et %d autre(s) peuvent être mis à jour.";


### PR DESCRIPTION
This PR is the continuation of #1329. I wasn't happy with my first implementation, so I made another one much simpler.

First I did add the Background Modes / Background Fetch capability.

When the system wakes Zebra from background, I call :

```objc
[databaseManager updateDatabaseUsingCaching:NO userRequested:YES];
```

The ZBNotificationManager class is a database delegate which will be triggered after each database update (including the one triggered by the above line).

If the numberOfUpdates parameter is not 0, it will perform a diff between the last update list and the new one. If there is any difference it will trigger a notification. It makes the implementation completely stateless.

I've been running a build with notifications for about a week now, and the background wakes are really random. There wasn't any for the first 24h, then it started to run each few hours.

I think I'm done with this feature, so I'm waiting for your feedback.