### PR TITLE
[Changes] Fix empty community news cell

### DIFF
--- a/Zebra/Tabs/Changes/ZBChangesTableViewController.m
+++ b/Zebra/Tabs/Changes/ZBChangesTableViewController.m
@@ -177,10 +177,10 @@
 - (void)createHeader {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.tableView beginUpdates];
-        [self.collectionView reloadData];
         [UIView animateWithDuration:.25f animations:^{
             self.tableView.tableHeaderView.frame = CGRectMake(self.tableView.tableHeaderView.frame.origin.x, self.tableView.tableHeaderView.frame.origin.y, self.tableView.tableHeaderView.frame.size.width, 180);
         }];
+        [self.collectionView reloadData];
         [self.tableView endUpdates];
     });
 }
@@ -522,7 +522,7 @@
 
 - (void)toggleNews {
     if ([ZBSettings wantsCommunityNews]) {
-        [self retrieveNewsJson];
+        [self kickStartReddit];
     } else {
         [self.redditPosts removeAllObjects];
         [self hideHeader];


### PR DESCRIPTION
Fix empty community news cells when `community news` was enabled after opening Zebra.