### PR TITLE
[Tab] Show package number that has an update

### DIFF
--- a/Zebra/Tabs/ZBTabBarController.m
+++ b/Zebra/Tabs/ZBTabBarController.m
@@ -67,6 +67,7 @@
 
     NSInteger badgeValue = [[UIApplication sharedApplication] applicationIconBadgeNumber];
     [self setPackageUpdateBadgeValue:(int)badgeValue];
+    [self updatePackagesTableView];
     
     databaseManager = [ZBDatabaseManager sharedInstance];
     if (![databaseManager needsToPresentRefresh]) {


### PR DESCRIPTION
Fix a bug where Zebra didn't show a package number that has an update on package tab when opening Zebra sometimes