### PR TITLE
Fix JSON Parsing When Extra Keys are In the dictionary

### DIFF
--- a/Zebra/JSONParsing/ZBPurchaseInfo.m
+++ b/Zebra/JSONParsing/ZBPurchaseInfo.m
@@ -72,7 +72,15 @@ NSString *_Nullable ZBPurchaseInfoToJSON(ZBPurchaseInfo *purchaseInfo, NSStringE
     self = [super init];
     
     if (self) {
-        [self setValuesForKeysWithDictionary:dict];
+        for (NSString* key in dict) {
+            @try {
+                [self setValue:dict[key] forKey:key];
+            } @catch (NSException *exception) {
+                if (![exception.name isEqualToString: @"NSUnknownKeyException"]) {
+                    @throw exception;
+                }
+            }
+        }
     }
     
     return self;

--- a/Zebra/JSONParsing/ZBSourceInfo.m
+++ b/Zebra/JSONParsing/ZBSourceInfo.m
@@ -85,7 +85,15 @@ NSString *_Nullable ZBSourceInfoToJSON(ZBSourceInfo *sourceInfo, NSStringEncodin
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dict
 {
     if (self = [super init]) {
-        [self setValuesForKeysWithDictionary:dict];
+        for (NSString* key in dict) {
+            @try {
+                [self setValue:dict[key] forKey:key];
+            } @catch (NSException *exception) {
+                if (![exception.name isEqualToString: @"NSUnknownKeyException"]) {
+                    @throw exception;
+                }
+            }
+        }
         _authenticationBanner = [ZBAuthenticationBanner fromJSONDictionary:(id)_authenticationBanner];
     }
     return self;
@@ -147,7 +155,15 @@ NSString *_Nullable ZBSourceInfoToJSON(ZBSourceInfo *sourceInfo, NSStringEncodin
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dict
 {
     if (self = [super init]) {
-        [self setValuesForKeysWithDictionary:dict];
+        for (NSString* key in dict) {
+            @try {
+                [self setValue:dict[key] forKey:key];
+            } @catch (NSException *exception) {
+                if (![exception.name isEqualToString: @"NSUnknownKeyException"]) {
+                    @throw exception;
+                }
+            }
+        }
     }
     return self;
 }

--- a/Zebra/JSONParsing/ZBUserInfo.m
+++ b/Zebra/JSONParsing/ZBUserInfo.m
@@ -88,7 +88,15 @@ NSString *_Nullable ZBUserInfoToJSON(ZBUserInfo *userInfo, NSStringEncoding enco
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dict
 {
     if (self = [super init]) {
-        [self setValuesForKeysWithDictionary:dict];
+        for (NSString* key in dict) {
+            @try {
+                [self setValue:dict[key] forKey:key];
+            } @catch (NSException *exception) {
+                if (![exception.name isEqualToString: @"NSUnknownKeyException"]) {
+                    @throw exception;
+                }
+            }
+        }
         _user = [ZBUser fromJSONDictionary:(id)_user];
     }
     return self;
@@ -135,7 +143,15 @@ NSString *_Nullable ZBUserInfoToJSON(ZBUserInfo *userInfo, NSStringEncoding enco
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dict
 {
     if (self = [super init]) {
-        [self setValuesForKeysWithDictionary:dict];
+        for (NSString* key in dict) {
+            @try {
+                [self setValue:dict[key] forKey:key];
+            } @catch (NSException *exception) {
+                if (![exception.name isEqualToString: @"NSUnknownKeyException"]) {
+                    @throw exception;
+                }
+            }
+        }
     }
     return self;
 }


### PR DESCRIPTION
Fixes a bug that resulted in NSJSONSerialization errors when repos added extra keys to JSON Objects such as user_info