### PR TITLE
Add Apex and Amethyst, change userspace reboot support method

### DIFF
--- a/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
+++ b/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
@@ -196,6 +196,24 @@
                             @"url" : @"https://ellekit.space/",
                             @"icon": @"https://ellekit.space/CydiaIcon.png"}];
         break;
+            
+    case ZBJailbreakAmethyst:
+        [result addObject:@{@"type": @"utility",
+                            @"name": @"Procursus",
+                            @"url" : @"https://apt.procurs.us/",
+                            @"icon": @"https://apt.procurs.us/CydiaIcon.png"}];
+        break;
+            
+    case ZBJailbreakApex:
+        [result addObject:@{@"type": @"utility",
+                            @"name": @"Procursus",
+                            @"url" : @"https://apt.procurs.us/",
+                            @"icon": @"https://apt.procurs.us/CydiaIcon.png"}];
+        [result addObject:@{@"type": @"utility",
+                            @"name": @"Odyssey Repo",
+                            @"url" : @"https://repo.theodyssey.dev/",
+                            @"icon": @"https://repo.theodyssey.dev/CydiaIcon.png"}];
+        break;
 
 
     default:

--- a/Zebra/ZBDevice.h
+++ b/Zebra/ZBDevice.h
@@ -41,7 +41,9 @@ typedef NS_ENUM(NSUInteger, ZBJailbreak) {
     ZBJailbreakMineekJB64,
     ZBJailbreakMineekJB,
     ZBJailbreakBakera1n,
-    ZBJailbreakP0insettia
+    ZBJailbreakP0insettia,
+    ZBJailbreakAmethyst,
+    ZBJailbreakApex
 };
 
 typedef NS_ENUM(NSUInteger, ZBBootstrap) {
@@ -75,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)debianArchitecture;
 + (nullable NSString *)packageManagementBinary;
 + (NSString *)path;
++ (BOOL)supportsUserspaceReboot;
 
 + (void)hapticButton;
 

--- a/Zebra/ZBDevice.m
+++ b/Zebra/ZBDevice.m
@@ -76,6 +76,24 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
 #endif
 }
 
++ (BOOL)supportsUserspaceReboot {
+    // all detectable iOS 14+ jailbreaks support userspace reboots
+    if (@available(iOS 14, *)) {
+        if (self.jailbreak != ZBJailbreakUnknown && self.jailbreak != ZBJailbreakSimulated) {
+            return YES;
+        }
+    }
+    
+    switch (self.jailbreak) {
+        case ZBJailbreakCheckra1n:
+        case ZBJailbreakChimera:
+        case ZBJailbreakOdyssey:
+        case ZBJailbreakAmethyst: return YES;
+        default: break;
+    }
+    return NO;
+}
+
 + (BOOL)isSlingshotBroken:(NSError *_Nullable*_Nullable)error {
 #if TARGET_OS_SIMULATOR
     return NO; //Since simulated devices don't have su/sling, it isn't broken!
@@ -247,7 +265,7 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
 
 + (void)restartDevice {
     if (![self needsSimulation]) {
-        if (@available(iOS 15, *)) {
+        if ([self supportsUserspaceReboot]) {
             // Try userspace reboot
             NSLog(@"[Zebra] Trying userspace reboot");
             if ([ZBCommand execute:@"launchctl" withArguments:@[@"reboot", @"userspace"] asRoot:YES]) {
@@ -345,7 +363,10 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
         @"/.installed_g0blin":     @(ZBJailbreakG0blin),
         @"/.installed_p0insettia": @(ZBJailbreakP0insettia),
         @"/cores/binpack/.installed_overlay": @(ZBJailbreakBakera1n),
+        @"/.installed_amethyst": @(ZBJailbreakAmethyst),
+        @"/.installed_apex": @(ZBJailbreakApex)
     };
+    
     NSDictionary <NSString *, NSNumber *> *jailbreakInstalledDirs = @{
         @"/binpack":      @(ZBJailbreakCheckra1n),
         @"/electra":      @(ZBJailbreakElectra),
@@ -439,6 +460,8 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     case ZBJailbreakMineekJB:    return @"mineekJB";
     case ZBJailbreakBakera1n:    return @"bakera1n";
     case ZBJailbreakP0insettia:  return @"p0insettia";
+    case ZBJailbreakAmethyst:    return @"Amethyst";
+    case ZBJailbreakApex:        return @"Apex";
     }
 }
 


### PR DESCRIPTION
Add Apex and Amethyst detection, change userspace reboot support method to be based on the installed jailbreak instead of checking if the device is on iOS 15+.