### PR TITLE
Ignore `buildServer.json` (for using VS Code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ xcuserdata/
 update.sh
 ipas/
 *.private.h
+/buildServer.json


### PR DESCRIPTION
(Requires the Swift extension, and the Sweetpad extension)